### PR TITLE
Add jump bait to blog post excerpts

### DIFF
--- a/src/partials/post_excerpt.hbs
+++ b/src/partials/post_excerpt.hbs
@@ -6,7 +6,7 @@
           <a href="{{ post_path this }}">{{ this.data.title }}</a>
         </h2>
       </header>
-      <p class="excerpt">{{ this.data.excerpt }}</p>
+      <p class="excerpt">{{ this.data.excerpt }} (<a href="{{ post_path this }}">...more</a>)</p>
       <footer>
         <ul class="post-meta">
           <li>{{ gravatar this.data.author_email 'sm' }}</li>


### PR DESCRIPTION
Using excerpts that are fully-formed sentences may confuse some potential readers. This would add an indicator link to each excerpt to view the full post. @sandersonet, thoughts?

![screenshot 2014-07-23 14 22 23](https://cloud.githubusercontent.com/assets/3422584/3680527/7b86326a-12af-11e4-8fda-ea59d94895b7.png)
