### PR TITLE
Don't alias users except for one-time sync

### DIFF
--- a/src/assets/javascript/contact-form.coffee
+++ b/src/assets/javascript/contact-form.coffee
@@ -23,10 +23,8 @@ $(document).ready ->
             # Trigger Customer.io tracking...
             analytics.page()
 
-            track_params = { name: nameVal, email: emailVal, message: messageVal }
-            analytics.alias emailVal
-            analytics.identify emailVal, name: nameVal, email: emailVal
-            analytics.track action, track_params
+            analytics.identify name: nameVal, email: emailVal
+            analytics.track action, { name: nameVal, email: emailVal, message: messageVal }
 
             messageContainer.addClass('alert-success').show()
             alertText.text('Thanks for your message!')

--- a/src/assets/javascript/newsletter.coffee
+++ b/src/assets/javascript/newsletter.coffee
@@ -24,8 +24,7 @@ $(document).ready ->
             # Trigger Customer.io tracking...
             analytics.page()
 
-            analytics.alias emailVal
-            analytics.identify emailVal, email: emailVal, newsletter_subscribed: true
+            analytics.identify email: emailVal, newsletter_subscribed: true
             analytics.track 'Subscribed To Newsletter', { email: emailVal }
             success.show()
             fields.hide()


### PR DESCRIPTION
This is part of what's necessary to make aptible/dashboard.aptible.com#234 work.

I won't try to re-explain the [Mixpanel docs](https://mixpanel.com/docs/integration-libraries/using-mixpanel-alias) on the subject, and conceptually it's a bit complicated, but basically: multiple aliases can make different streams of client-side and server-side events permanently unlinkable.

The best rule of thumb I have right now is: only alias once, from an anonymous client-side identity to a permanent server-side identity, as soon as we're able. As long as we stick to this, we should be good.
