### PR TITLE
Use bundle exec for compass

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -94,6 +94,7 @@ module.exports = function(grunt) {
 
         compass: {
             options: {
+                bundleExec: true,
                 config: 'compass.rb'
             },
             site: {


### PR DESCRIPTION
@sandersonet for you to review/merge.

The build issue on my box was due to my local version of gems not matching what the `Gemfile.lock` asked for. Bundler will always use those versions, so I suspected that Grunt was calling ruby commands without the `bundle exec` prefix.

Turns out there is an option to configure this. I've enabled it here. My local builds run just fine now :-)