### PR TITLE
Use data.order to sort Agreements

### DIFF
--- a/src/partials/legal_index.hbs
+++ b/src/partials/legal_index.hbs
@@ -1,6 +1,6 @@
 <div class="list-group">
   <li class="list-group-item list-group-title">Agreements</li>
-  {{#withSort pages 'data.title' }}
+  {{#withSort pages 'data.order' }}
     {{#is data.section 'Legal'}}
       {{#is data.sub_section 'Agreements' }}
 


### PR DESCRIPTION
@sandersonet  This, along with the corresponding frontmatter, allows us to specify the order in which Agreements appear in the legal index sidebar.