### PR TITLE
Always run installs to ensure dependencies are local

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -355,14 +355,23 @@ module.exports = function(grunt) {
         }
     });
 
+    grunt.registerTask('install', 'install dependencies', function() {
+        var exec = require('child_process').exec;
+        var cb = this.async();
+        exec('bundle install; npm install; bower install', {}, function(err, stdout, stderr) {
+            console.log(stdout);
+            cb();
+        });
+    });
+
     grunt.registerTask('env', 'Set environment variable', function(env) {
         console.log(grunt.config.get('assemble.options.data'));
         grunt.config.set('assemble.options.env', env);
     });
 
-    grunt.registerTask('setup', ['auto_install', 'gitclone']);
+    grunt.registerTask('setup', ['install', 'auto_install', 'gitclone']);
     grunt.registerTask('update', ['require_setup', 'gitpull']);
-    grunt.registerTask('dist', ['require_setup', 'clean', 'copy:assets', 'assemble', 'compass:site', 'coffee:compile']);
+    grunt.registerTask('dist', ['require_setup', 'install', 'clean', 'copy:assets', 'assemble', 'compass:site', 'coffee:compile']);
     grunt.registerTask('release:production', ['env:production', 'dist', 'exec:s3_sync:www.aptible.com']);
     grunt.registerTask('release:staging', ['env:staging', 'dist', 'exec:s3_sync:www.aptible-staging.com']);
     grunt.registerTask('server', ['dist', 'connect', 'watch']);

--- a/README.md
+++ b/README.md
@@ -8,15 +8,16 @@ This is a static site generator that pulls in content pages from the [aptible-pa
 #### Setting up
 
 ````
-bundle install
-npm install
-bower install
 grunt setup
 ````
 
 #### Local Development
 
 `grunt setup` clones the aptible-pages, aptible-legal, and aptible-blog repos into the `content` folder. You can add your own fork as a remote and submit PRs for those repos directly. Run `grunt update` to pull the latest revisions of all dependent content repos.
+
+`grunt setup`, `grunt server`, and the deploy tasks all ensure dependencies are
+installed locally by running `bundle install`, `npm install`, and
+`bower install`.
 
 Run `grunt server` to see your changes on localhost.
 
@@ -27,20 +28,17 @@ The site is built with [Assemble](http://assemble.io/). Many of the files make u
 This will release the site to an S3 bucket where it will be immediately accessible at [www.aptible.com](https://www.aptible.com). The `release` commands depend on the [AWS command line tool](http://aws.amazon.com/cli/), which should be set up according to [Aptible's best practices](https://github.com/aptible/aptible-tech-guide/blob/master/doc/SystemsAdministration.md#command-line-access).
 
 ````
-bundle install
-npm install
-bower install
 grunt release:production
 ````
 
 To release to our staging site ([www.aptible-staging.com](https://www.aptible-staging.com)):
 
 ````
-bundle install
-npm install
-bower install
 grunt release:staging
 ````
+
+Note: these tasks also run `bundle install`, `npm install`, and `bower install`
+to ensure all dependencies are included in deploys.
 
 Copyright &copy; 2015 Aptible
 

--- a/script/travis-deploy.sh
+++ b/script/travis-deploy.sh
@@ -8,8 +8,7 @@ if [ "$TRAVIS_BRANCH" == "master" ] &&
 
   # Setup/install
   bundle install --deployment --retry 3
-  npm install
-  bower install
+  # Setup runs npm and bower installs
   grunt setup
   pip install --user awscli
 


### PR DESCRIPTION
I accidentally deployed a copy of www to production that did not include a query plugin needed by the new technology page. I want to ensure that doesn't happen again and don't trust myself to always run the installs... so, this change is a little ham-fisted :fist:. It ensures dependencies are always installed locally by running bundle, npm, and bower installs as part of the setup, server, and deploy tasks.

What do you think @sandersonet? I'm sure there are a few other (better?) ways of achieving this. I'm new to grunt. ¯\\\_(°\_o)\_/¯