### PR TITLE
Restore console styles

### DIFF
--- a/src/assets/stylesheets/_home.scss
+++ b/src/assets/stylesheets/_home.scss
@@ -342,3 +342,50 @@ header.primary-header {
     margin-bottom: 0;
   }
 }
+
+.home .console {
+  @include border-radius(5px);
+  @include box-shadow(0 0 12px rgba(#000, .12));
+  .console-title-bar {
+    height: 37px;
+    padding: 10px;
+    border: 1px solid #d9d9d9;
+    border-width: 1px 1px 0;
+    border-radius: 5px;
+    background-image: -o-linear-gradient(-89deg, #f6f6f6 0%, #f0f0f0 100%);
+    background-image: -moz-linear-gradient(-89deg, #f6f6f6 0%, #f0f0f0 100%);
+    background-image: -ms-linear-gradient(-89deg, #f6f6f6 0%, #f0f0f0 100%);
+    background-image: linear-gradient(-179deg, #f6f6f6 0%, #f0f0f0 100%);
+    @include box-shadow(inset 0 1px 0 0 #fff);
+    @include border-radius(5px 5px 0 0);
+    .osx-button {
+      height: 12px;
+      width: 12px;
+      background: #d8d8d8;
+      display: inline-block;
+      margin-right: 5px;
+      @include box-shadow(0 1px 0 0 #fff, inset 0 1px 3px 0 rgba(#000, .13));
+      @include border-radius(6px);
+    }
+  }
+  code.console-body {
+    display: block;
+    background: #223e4e;
+    padding: 10px;
+    color: #fff;
+    font-size: 13px;
+    line-height: 17px;
+    height: 336px;
+    font-family: "Inconsolata", Menlo, Monaco, monospace;
+    @include border-radius(0 0 5px 5px);
+    .console-group {
+      margin-bottom: 20px;
+    }
+    .subdued-color {
+      color: #aadeed;
+    }
+    .success-color {
+      color: #87ce1b;
+    }
+  }
+}


### PR DESCRIPTION
Closes https://github.com/aptible/www.aptible.com/issues/142

I ended up scoping these styles to the home page (`.home`). Disappointing.
It was this or change the technology markup or remove styles on the technology console. We can go there if we need a styled console like this elsewhere.