### PR TITLE
Fix for smaller screens getting a full viewport header

### DIFF
--- a/src/assets/stylesheets/_mobile_xs.scss
+++ b/src/assets/stylesheets/_mobile_xs.scss
@@ -49,7 +49,6 @@ header.primary-header {
 }
 
 .home.index header.primary-header {
-  min-height: 100%;
   height: auto;
 
   .primary-header-bg {


### PR DESCRIPTION
### Before / After
<img width="45%" alt="screen shot 2015-08-27 at 1 40 54 pm" src="https://cloud.githubusercontent.com/assets/94830/9531122/5e035518-4cc1-11e5-9da8-792889f21fa1.png" style="float: left; margin-right: 30px;"> <img width="45%" alt="screen shot 2015-08-27 at 1 41 08 pm" src="https://cloud.githubusercontent.com/assets/94830/9531125/62fac1a0-4cc1-11e5-80ab-53570c74ca2a.png" style="float: right;">


