### PR TITLE
Override desktop min-width setting for mobile.

### DIFF
--- a/src/assets/stylesheets/_mobile_xs.scss
+++ b/src/assets/stylesheets/_mobile_xs.scss
@@ -143,6 +143,7 @@ header.primary-header {
 footer.aptible-footer {
   padding: 25px 0;
   margin-top: 0;
+  min-width: 100%;
 
   .nav {
     margin: 0 0 25px;


### PR DESCRIPTION
Currently, aptible-sass is forcing min-width to 980px for `footer.aptible-footer` (here https://github.com/aptible/aptible-sass/blob/c032609bf149e70462958a48cd71b55d6ea0c19a/dist/styles/aptible_nav.scss#L295).

This fix overrides that setting, but it may be a "quick-fix" and not the correct final solution. We should definitely confirm with @sandersonet and @gib, but we can probably deploy this for now...