### PR TITLE
Fixes the busted career image

### DIFF
--- a/src/assets/stylesheets/_about.scss
+++ b/src/assets/stylesheets/_about.scss
@@ -46,7 +46,7 @@
   }
 }
 
-.aptible-careers {
+.careers {
   .carousel {
     height: 396px;
     background: $color-bg-gray;
@@ -65,6 +65,9 @@
     .carousel-item {
       height: 396px;
       overflow: hidden;
+      img {
+        max-height: 100%;
+      }
     }
 
     .carousel-caption {


### PR DESCRIPTION
The career page got busted with some recent updates. I thought it was it's style classes overlapping with the new home page carousel, but that's not it.

I have another branch with more images (team in mexico!), but had to table for time.