### PR TITLE
Pricing Calculator Updates

### DIFF
--- a/src/assets/javascript/price_calc_state.coffee
+++ b/src/assets/javascript/price_calc_state.coffee
@@ -9,25 +9,28 @@ class PriceCalculator
   # Mutable Attributes
   handlesPHI    : false
   fullService   : false
-  containers    : 0
-  disks         : 0
-  domains       : 0
+  containers    : 2
+  disks         : 1
+  domains       : 1
   prevContainers: 0
   prevDisks     : 0
   prevDomains   : 0
 
   # Fixed
-  # Disks are 200 GB each
-  devContainers : 6
-  devDisks      : 5
-  devDomains    : 4
+  phiContainers : 6
+  phiDisks      : 8
+  phiDomains    : 4
+
+  diskValuesGB  : [0, 10, 20, 50, 100, 250, 500, 750, 1000, 1500, 2000]
+  diskLabels    : ['0 GB', '10 GB', '20 GB', '50 GB', '100 GB', '250 GB',
+                   '500 GB', '750 GB', '1 TB', '1.5 TB', '2 TB']
 
   # Prices
   # ~730 hours in a month
   perContainer  : (0.08 * 730).toFixed 2
-  perDisk       : (0.37 * 200).toFixed 2
+  perDisk       : (gb) -> (0.37 * gb).toFixed 2
   perDomain     : (0.05 * 730).toFixed 2
-  devBaseCost   : 499
+  phiBaseCost   : 499
 
   # Retain higher values if set, only up to what's included
   setDevBaseValues: ->
@@ -35,9 +38,9 @@ class PriceCalculator
       @prevContainers = @containers
       @prevDisks = @disks
       @prevDomains = @domains
-      @containers = Math.max(@containers, @devContainers)
-      @disks = Math.max(@disks, @devDisks)
-      @domains = Math.max(@domains, @devDomains)
+      @containers = Math.max(@containers, @phiContainers)
+      @disks = Math.max(@disks, @phiDisks)
+      @domains = Math.max(@domains, @phiDomains)
     else # restore
       @containers = @prevContainers
       @disks = @prevDisks
@@ -48,35 +51,29 @@ class PriceCalculator
   # is above or at the included dev values
   setValue: (attr, value) ->
     attrCap = attr[0].toUpperCase() + attr[1..]
-    @["prev#{attrCap}"] = value if @handlesPHI and value >= @["dev#{attrCap}"]
+    @["prev#{attrCap}"] = value if @handlesPHI and value >= @["phi#{attrCap}"]
     @[attr] = value
 
-  diskSize: ->
-    switch @disks
-      when 0, 1, 2, 3, 4
-        "#{@disks * 200} GB"
-      when 5, 10
-        "#{@disks * 0.2} TB"
-      else
-        "#{(@disks * 0.2).toFixed(1)} TB"
+  diskSize: -> @diskLabels[@disks]
 
   containersCost: ->
-    includedContainers = if @handlesPHI then @devContainers else 0
+    includedContainers = if @handlesPHI then @phiContainers else 0
     containers = if @containers > 10 then 10 else @containers
     @toCurrency Math.max(((containers - includedContainers) * @perContainer), 0)
 
   disksCost: ->
-    includedDisks = if @handlesPHI then @devDisks else 0
-    disks = if @disks > 10 then 10 else @disks
-    @toCurrency Math.max(((disks - includedDisks) * @perDisk), 0)
+    includedGB = @diskValuesGB[if @handlesPHI then @phiDisks else 0]
+    diskGB = @diskValuesGB[if @disks > 10 then 10 else @disks]
+    gb = Math.max(diskGB - includedGB, 0)
+    @toCurrency parseFloat(@perDisk(gb))
 
   domainsCost: ->
-    includedDomains = if @handlesPHI then @devDomains else 0
+    includedDomains = if @handlesPHI then @phiDomains else 0
     domains = if @domains > 10 then 10 else @domains
     @toCurrency Math.max(((domains - includedDomains) * @perDomain), 0)
 
   baseCost: ->
-    @toCurrency(if @handlesPHI then @devBaseCost else 0)
+    @toCurrency(if @handlesPHI then @phiBaseCost else 0)
 
   price: ->
     @toCurrency(

--- a/src/assets/stylesheets/_price_calc.scss
+++ b/src/assets/stylesheets/_price_calc.scss
@@ -130,6 +130,10 @@ $color-lighter-gray: #d8d6d6;
   .price-calc[data-full-service='on'] .price-calc__step--summary {
     width: 66.66%;
   }
+  .price-calc__step--summaries {
+    height: auto;
+    padding-bottom: 50px;
+  }
 }
 
 @media (max-width: $screen-xs-min) {
@@ -144,6 +148,7 @@ $color-lighter-gray: #d8d6d6;
       width: 100%;
     }
     .price-calc__submit {
+      display: block;
       float: none;
       margin-top: 0;
       width: 100%;
@@ -257,7 +262,7 @@ $color-lighter-gray: #d8d6d6;
 }
 .price-calc__disk {
   .price-calc__included {
-    width: calc(45.5% - 6px);
+    width: calc(71.5% - 6px);
   }
 }
 .price-calc__domains {
@@ -437,4 +442,75 @@ $color-lighter-gray: #d8d6d6;
     font-weight: 200;
     line-height: 48px;
   }
+}
+
+//
+// Bonus Credit
+//
+.price-calc__bonus-credit {
+  background-color: #2ecc71;
+  height: 75px;
+  opacity: 0;
+  padding-top: 15px;
+  position: absolute;
+  right: 0;
+  text-align: center;
+  transform: scale(0) translateY(-8px) rotate(-15deg);
+  @include transition(all 0.5s cubic-bezier(0.68, -0.55, 0.265, 1.55));
+  width: 75px;
+  b, i {
+    color: #fff;
+    display: block;
+    font-weight: bold;
+    letter-spacing: 0.05em;
+    margin: 0;
+    text-transform: uppercase;
+  }
+  b {
+    font-size: 24px;
+  }
+  i {
+    font-size: 12px;
+    font-style: normal;
+    letter-spacing: 0.15em;
+  }
+  .price-calc[data-phi='off'][data-full-service='off'] & {
+    opacity: 1;
+    transform: scale(1) translateY(-8px) rotate(15deg)
+  }
+}
+.starburst,
+.starburst span {
+  display: box;
+  box-align: center;
+  box-pack: center;
+}
+.starburst span {
+  width: 100%;
+  height: 100%;
+  background: inherit;
+  transform: rotate(45deg);
+}
+.starburst:before,
+.starburst:after ,
+.starburst span:before,
+.starburst span:after {
+   content: "";
+   position: absolute;
+   top: 0;
+   left: 0;
+   width: 100%;
+   height: 100%;
+   background: inherit;
+   z-index: -1;
+  transform: rotate(30deg);
+}
+.starburst:after {
+  transform: rotate(-30deg);
+}
+.starburst span:after {
+  transform: rotate(30deg);
+}
+.starburst span:before {
+  transform: rotate(-30deg);
 }

--- a/src/partials/pricing_calculator.hbs
+++ b/src/partials/pricing_calculator.hbs
@@ -48,7 +48,7 @@
             <li class="price-calc__range-key" data-value="&plus;">&plus;</li>
           </ul>
           <div class="price-calc__range">
-            <input type="range" min="0" max="11" step="1" value="0" data-type="containers">
+            <input type="range" min="0" max="11" step="1" value="2" data-type="containers">
           </div>
           <div class="price-calc__included"></div>
         </div>
@@ -60,20 +60,20 @@
           </h3>
           <ul class="price-calc__range-keys" data-type="disks">
             <li class="price-calc__range-key" data-value="0">0</li>
-            <li class="price-calc__range-key" data-value="200GB">&centerdot;</li>
-            <li class="price-calc__range-key" data-value="400GB">&centerdot;</li>
-            <li class="price-calc__range-key" data-value="600GB">&centerdot;</li>
-            <li class="price-calc__range-key" data-value="800GB">&centerdot;</li>
+            <li class="price-calc__range-key" data-value="10GB">&centerdot;</li>
+            <li class="price-calc__range-key" data-value="20GB">&centerdot;</li>
+            <li class="price-calc__range-key" data-value="50GB">&centerdot;</li>
+            <li class="price-calc__range-key" data-value="100GB">&centerdot;</li>
+            <li class="price-calc__range-key" data-value="250GB">&centerdot;</li>
+            <li class="price-calc__range-key" data-value="500GB">&centerdot;</li>
+            <li class="price-calc__range-key" data-value="750GB">&centerdot;</li>
             <li class="price-calc__range-key" data-value="1TB">1TB</li>
-            <li class="price-calc__range-key" data-value="1.2TB">&centerdot;</li>
-            <li class="price-calc__range-key" data-value="1.4TB">&centerdot;</li>
-            <li class="price-calc__range-key" data-value="1.6TB">&centerdot;</li>
-            <li class="price-calc__range-key" data-value="1.8TB">&centerdot;</li>
+            <li class="price-calc__range-key" data-value="1.5TB">&centerdot;</li>
             <li class="price-calc__range-key" data-value="2TB">&centerdot;</li>
             <li class="price-calc__range-key" data-value="&plus;">&plus;</li>
           </ul>
           <div class="price-calc__range">
-            <input type="range" min="0" max="11" step="1" value="0" data-type="disks">
+            <input type="range" min="0" max="11" step="1" value="1" data-type="disks">
           </div>
           <div class="price-calc__included"></div>
         </div>
@@ -98,7 +98,7 @@
             <li class="price-calc__range-key" data-value="&plus;">&plus;</li>
           </ul>
           <div class="price-calc__range">
-            <input type="range" min="0" max="11" step="1" value="0" data-type="domains">
+            <input type="range" min="0" max="11" step="1" value="1" data-type="domains">
           </div>
           <div class="price-calc__included"></div>
         </div>
@@ -188,12 +188,17 @@
               </tr>
             </tbody>
           </table>
-					<table class="price-calc__data-summary price-calc__monthly-summary">
+          <div class="price-calc__bonus-credit starburst">
+            <span><b>{{intro_credit}}</b> <i>credit</i></span>
+          </div>
+          <table class="price-calc__data-summary price-calc__monthly-summary">
             <thead><tr><th class="caps">Total</th></tr></thead>
             <tbody><tr><td class="price-calc__monthly-total"></td></tr></tbody>
           </table>
 				</div>
-        <a class="price-calc__submit btn btn-primary btn-lg" href="https://dashboard.aptible.com/signup?plan=development">Get Started Now</a>
+        <a class="price-calc__submit btn btn-primary btn-lg" href="https://dashboard.aptible.com/signup?plan=development">
+          {{pricing_cta}}
+        </a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
- Initializes the calculator at common base usage for a running app, (2
containers, 10GB DB, 1 Domain)
- DB slider is no longer linear, starting with smaller GB increments
- Call out for the $500 credit by the monthly total $ estimate and
getting started call-to-action

Closes #173 (thanks @wcpines)

![pricing-calc-updates](https://cloud.githubusercontent.com/assets/94830/11576487/3236f6b4-99d4-11e5-8140-bbea1f6fa70a.gif)
