### PR TITLE
Use tracked_title for legal sidebar titles

### DIFF
--- a/src/partials/legal_index.hbs
+++ b/src/partials/legal_index.hbs
@@ -5,7 +5,7 @@
       {{#is data.sub_section 'Agreements' }}
 
         <a href="{{legal_path this}}" class="list-group-item">
-          {{this.data.title}}
+          {{this.data.tracked_title}}
         </a>
 
       {{/is}}
@@ -20,7 +20,7 @@
       {{#is data.sub_section 'Policies'}}
 
         <a href="{{ legal_path this}}" class="list-group-item">
-          {{this.data.title}}
+          {{this.data.tracked_title}}
         </a>
 
       {{/is}}


### PR DESCRIPTION
@sandersonet - Any issue with using `tracked_title` in the policy/agreement frontmatter as a short version to display in the sidebar? It eliminates some redundancy.

Old:
<img width="295" alt="screenshot 2016-01-27 13 53 06" src="https://cloud.githubusercontent.com/assets/3422584/12624504/705f18b4-c4fd-11e5-8300-e70c16cdc134.png">

New:
<img width="292" alt="screenshot 2016-01-27 13 53 19" src="https://cloud.githubusercontent.com/assets/3422584/12624506/742b1a60-c4fd-11e5-8b1b-53ab6a330f39.png">