### PR TITLE
Support Updates

### DIFF
--- a/src/assets/stylesheets/_product_pages.scss
+++ b/src/assets/stylesheets/_product_pages.scss
@@ -62,6 +62,7 @@
   margin-left: 10%;
   margin-right: 10%;
   margin-bottom: 20px;
+  text-align: center;
 }
 .text-hero__sub-title {
   line-height: 1.5em;
@@ -69,6 +70,7 @@
   margin-right: 12%;
   margin-bottom: 30px;
   margin-top: 0;
+  text-align: center;
 }
 
 //

--- a/src/assets/stylesheets/_support_plans.scss
+++ b/src/assets/stylesheets/_support_plans.scss
@@ -1,0 +1,69 @@
+//
+// Support Plans
+//
+.support-plans {
+  .row.section:last-of-type {
+    margin-bottom: 100px;
+  }
+  .row.section.bordered {
+    margin-bottom: 0;
+  }
+}
+.support-plan-tiers {
+  width: 100%;
+  th {
+    color: #0272b7;
+    font-family: 'proxima-nova', Helvetica, sans-serif;
+    font-size: 18px;
+    font-weight: bold;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    -webkit-font-smoothing: antialiased;
+  }
+  th, td {
+    padding: 12px;
+    vertical-align: top;
+  }
+  tr {
+    &:nth-child(even) {
+      // background-color: rgba(0,0,0,0.005);
+    }
+    td:first-child {
+      // border-left: none;
+      color: #333;
+      font-weight: bold;
+      padding-right: 15px;
+      text-align: right;
+      text-transform: uppercase;
+    }
+  }
+  tbody {
+    tr:first-of-type td {
+      border-top: 2px solid #0272b7;
+      padding-top: 28px;
+    }
+    td {
+      // border-left: 1px solid rgba(0,0,0,0.05);
+      border-top: 1px solid #e7e7e7;
+      font-size: 14px;
+    }
+  }
+}
+.support-plan-tiers {
+  th, td { width: 25%; }
+}
+.response-times-description {
+  margin-top: 20px;
+  th, td { width: 16%; }
+}
+.small-hero-list {
+  width: 100%;
+  th {
+    text-align: right;
+  }
+  th, td {
+    padding: 10px;
+    width: 50%;
+    vertical-align: top;
+  }
+}

--- a/src/assets/stylesheets/main.scss
+++ b/src/assets/stylesheets/main.scss
@@ -24,4 +24,5 @@
 @import 'resources';
 @import 'full_page';
 @import 'product_pages';
+@import 'support_plans';
 @import 'layout';

--- a/src/layouts/error.hbs
+++ b/src/layouts/error.hbs
@@ -105,7 +105,7 @@
   <ul>
     <li><a href="http://status.aptible.com">Aptible Status</a></li>
     <li><a href="https://twitter.com/aptiblestatus">@aptiblestatus</a></li>
-    <li><a href="http://support.aptible.com">Contact Support</a></li>
+    <li><a href="https://aptible.zendesk.com/hc/en-us/requests/new">Contact Support</a></li>
   </ul>
   <a class="circle-icon" href="https://www.aptible.com"></a>
 </body>

--- a/src/partials/company_nav.hbs
+++ b/src/partials/company_nav.hbs
@@ -28,9 +28,6 @@
         <li {{#is dirname 'dist/company/careers'}} class="active"{{/is}}>
           <a href="/company/careers">Careers</a>
         </li>
-        <li {{#is dirname 'dist/company/contact'}} class="active"{{/is}}>
-          <a href="/company/contact">Contact</a>
-        </li>
         <li {{#is dirname 'dist/company/resources'}} class="active"{{/is}}>
           <a href="/company/resources">Resources</a>
         </li>

--- a/src/partials/footer.hbs
+++ b/src/partials/footer.hbs
@@ -26,7 +26,7 @@
           <div class="col-sm-4">
             <ul class="nav">
               <li class="title">Support</li>
-              <li><a href="https://support.aptible.com/contact">Contact Us</a></li>
+              <li><a href="https://aptible.zendesk.com/hc/en-us/requests/new">Contact Us</a></li>
               <li><a href="https://support.aptible.com/quickstart">Quickstart Guides</a></li>
               <li><a href="/legal/responsible_disclosure.html">Responsible Disclosure</a></li>
               <li><a href="{{config.status_url}}">Status</a></li>


### PR DESCRIPTION
- styles for tiered support plans page
- updated all “contact us” links to the ZD form
- removed “contact us” link from the company sub nav

![support](https://cloud.githubusercontent.com/assets/94830/12806949/edf3b292-cac7-11e5-9fa6-e1d1a17604f9.png)

Could possibly use some intro copy and @sandersonet is working on a design update (@chasballew).

Should be merged with
- https://github.com/aptible/aptible-pages/pull/66
- https://github.com/aptible/support/pull/226