### PR TITLE
Add the full footer to the landing page template

### DIFF
--- a/src/layouts/landing-page.hbs
+++ b/src/layouts/landing-page.hbs
@@ -9,10 +9,7 @@
 
     {{> body}}
 
-    <footer class="aptible-footer">
-      <div class="aptible-mark"><div class="mark"></div></div>
-      <div class="landing-page__copyright">© 2016 Aptible</div>
-    </footer>
+    {{> footer}}
 
     {{> javascripts}}
   </body>


### PR DESCRIPTION
** Before **
![screencapture-www-aptible-com-webinars-getting-started-with-researchkit-1463178131892](https://cloud.githubusercontent.com/assets/94830/15263400/ead1b9c6-1926-11e6-82ab-130356cc4cf7.png)

** After **
![screencapture-localhost-8000-webinars-getting-started-with-researchkit-1463178009424](https://cloud.githubusercontent.com/assets/94830/15263377/bc5c08da-1926-11e6-89a0-0ef2c44a6987.png)

@chasballew 