### PR TITLE
Use "endpoints" instead of "domains" or "vhosts"

### DIFF
--- a/content/legal/security.md
+++ b/content/legal/security.md
@@ -2,7 +2,7 @@
 title: Security Policy
 tracked_title: Security
 description: "Aptible's security policy"
-posted: 2015-12-17
+posted: 2016-06-12
 section: Legal
 sub_section: Policies
 ---
@@ -11,7 +11,7 @@ Aptible, Inc.
 =============
 Security Policy & Practices
 ---------------------
-Version 3.0 - December 2015
+Version 3.1 - June 2016
 
 This policy outlines: 1) Aptible's security practices and resources, and 2)  your security obligations. This policy is incorporated by reference into the Aptible Terms of Service.
 
@@ -86,7 +86,7 @@ You may choose to run a host-based intrusion detection or prevention system that
 
 #### **3. Platform Security**
 ##### **3.A - Configuration and Change Management**
-For app services that have a VHOST (SSL/TLS endpoint) attached, the Aptible platform performs a health check on the container set before promoting it to the current release. If the health check fails, the container set is not promoted. Either way, the deploy is zero-downtime.
+For app services that have an SSL/TLS endpoint attached, the Aptible platform performs a health check on the container set before promoting it to the current release. If the health check fails, the container set is not promoted. Either way, the deploy is zero-downtime.
 
 For any deploy, you can roll back to a previous codebase by pushing a different ref to your Aptible git endpoint.
 

--- a/content/pages/faq/index.hbs
+++ b/content/pages/faq/index.hbs
@@ -83,11 +83,11 @@ faq:
       - question: Disk
         answer: |
           Disk storage refers to the underlying volumes used for database storage. Disk storage is encrypted at the filesystem level with 192-bit AES encryption. Aptible manages the encryption keys for you. Disk pricing includes nightly backups for 90 days and monthly backups for 6 years. Backups are stored in a geographic region separate from where your database runs.
-      - question: Domain
+      - question: Endpoint
         answer: |
-          A domain, or "VHOST," is an SSL/TLS endpoint. Domains are attached to a service and consist of a DNS service, an AWS Elastic Load Balancer, and an NGiNX container.
-          To configure a VHOST, register a domain and procure an SSL certificate. (Wildcard, subdomain, and EV certificates all work.) After loading your VHOST with the certificate bundle and private key, you can point your domain's DNS to the endpoint.
-          "Internal" VHOSTs can be used to expose a private service to other services on the same stack. Internal VHOSTs receive private IP addresses and cannot be accessed from the Internet.
+          An endpoint is a networking resource that exposes an app or database service. An SSL/TLS endpoint, for example, is often used to expose a web service to the Internet. Endpoints consist of a DNS service, an AWS Elastic Load Balancer, and at least one NGiNX container.
+          To configure an SSL/TLS endpoint, register a domain and procure an SSL certificate. (Wildcard, subdomain, and EV certificates all work.) After loading your endpoint with the certificate bundle and private key, you can point your domain's DNS to the endpoint address.
+          "Internal" endpoints can be used to expose a private service to other services on the same stack. Internal endpoints receive private IP addresses and cannot be accessed from the Internet.
       - question: Service
         answer: |
           A service is comprised of one or more containers running the same process. By adding containers to a service, you can easily and quickly scale. Services run in your stack's app layer (see our [Reference Architecture Diagram](/pages/assets/aptible-reference-architecture.pdf)).

--- a/content/pages/pricing/index.hbs
+++ b/content/pages/pricing/index.hbs
@@ -30,7 +30,7 @@ plans:
     included:
     - 6 containers
     - 1TB disk
-    - 4 domains
+    - 4 endpoints
   managed:
     name: Managed
     descriptors:
@@ -38,9 +38,9 @@ plans:
     - "As a Managed Account partner, our engineering and compliance teams will work with you directly to help you quickly pass security reviews and audits at the largest healthcare institutions in the country."
 
 tooltip:
-  containers: 1 GB RAM Docker containers. Estimate 1 container per app process, plus 1 per database. Custom container sizes available.
+  containers: Docker containers, 1 GB RAM by default. Easily scale container count and RAM footprint. To start, plan for 1 container per app process, plus 1 per database.
   disk: "Encrypted database storage. Includes backups: daily for 90 days, monthly for 6 years."
-  domains: SSL endpoint. Balances load across your app containers. May be public or internal.
+  endpoints: Expose apps and databases to the Internet, or internally as private services.
 
 needs_more:
   title: Scale much?
@@ -59,9 +59,9 @@ discount:
     are participating.
 
 pricing:
-  container: $0.08/hour
+  container: $0.08/GB/hour
   disk: $0.37/GB/month
-  domain: $0.05/hour
+  endpoint: $0.05/hour
 
 support_plans:
   title: Support Plans
@@ -120,9 +120,9 @@ quick_start:
       <h2 class="section-title">Unit Pricing</h2>
       <ul class="plan-attributes">
         <li>All plans are scalable on demand, just pay for what you use:</li>
-        <li><strong>1 GB App/Database Containers:</strong> {{pricing.container}}</li>
+        <li><strong>App/Database Containers:</strong> {{pricing.container}}</li>
         <li><strong>Encrypted Disk:</strong> {{pricing.disk}}</li>
-        <li><strong>Domains:</strong> {{pricing.domain}}</li>
+        <li><strong>Endpoints:</strong> {{pricing.endpoint}}</li>
       </ul>
     </div>
   </div>

--- a/content/pages/technology/index.hbs
+++ b/content/pages/technology/index.hbs
@@ -33,7 +33,7 @@ databases:
 scale:
   title: Perform at Scale
   body: |-
-    Easily scale apps, domains, and databases with the security and reliability of the AWS cloud. Because your PHI-ready stacks are dedicated to you, the Aptible Container Platform has no performance tradeoff. Zero-downtime deploys make scaling seamless.
+    Easily scale apps, endpoints, and databases with the security and reliability of the AWS cloud. Because your PHI-ready stacks are dedicated to you, the Aptible Container Platform has no performance tradeoff. Zero-downtime deploys make scaling seamless.
 sign_up:
   title: Try Aptible Now with a Development Account
   cta1: Open a Development Account

--- a/src/partials/pricing_calculator.hbs
+++ b/src/partials/pricing_calculator.hbs
@@ -79,7 +79,7 @@
         </div>
         <div class="price-calc__domains">
           <h3 class="price-calc__config-item">
-            <dfn data-toggle="tooltip" data-title="{{tooltip.domains}}">Domains:</dfn>
+            <dfn data-toggle="tooltip" data-title="{{tooltip.endpoints}}">Endpoints:</dfn>
             <span class="price-calc__config-value price-calc__item-value--domains"></span>
             <span class="price-calc__config-price price-calc__item-price--domains"></span>
           </h3>
@@ -182,7 +182,7 @@
                 <td class="price-calc__item-price price-calc__item-price--disks"></td>
               </tr>
               <tr>
-                <td>Domains:</td>
+                <td>Endpoints:</td>
                 <td class="price-calc__item-value price-calc__item-value--domains"></td>
                 <td class="price-calc__item-price price-calc__item-price--domains"></td>
               </tr>


### PR DESCRIPTION
cc @fancyremarker @gib 

This terminology change is also reflected in aptible/dashboard.aptible.com#622 and aptible/support#268