### PR TITLE
Quickstart article updates

### DIFF
--- a/helpers/aptible_helpers.rb
+++ b/helpers/aptible_helpers.rb
@@ -11,6 +11,14 @@ module AptibleHelpers
     string_date.strftime('%B %e, %Y')
   end
 
+  def quickstart_index_href(language)
+    if language.articles.count == 1
+      language.url
+    else
+      "/support/quickstart/#{language.slug}"
+    end
+  end
+
   def latest_blog_post
     blog_posts_by_date.first
   end

--- a/source/layouts/support-document.haml
+++ b/source/layouts/support-document.haml
@@ -8,9 +8,9 @@
       %span.nav-item--separator
       - if quickstart? current_page.path
         %a.nav-item{:href => '/support/quickstart/'} Get Started Guides
-        - if @language_data
+        - if @language.articles.count > 1
           %span.nav-item--separator
-          %a.nav-item{:href => @language_data}= @language_data.name
+          %a.nav-item{:href => quickstart_index_href(@language)}= @language.name
         %span.nav-item--separator
         %a.nav-item{:href => ''} #{ @title }
       - else

--- a/source/layouts/support-document.haml
+++ b/source/layouts/support-document.haml
@@ -28,22 +28,25 @@
       %hr
 
       .grid-aside
-        .grid-aside__block
-          - if quickstart? current_page.path
+        - if quickstart? current_page.path
+          .grid-aside__block
             %h2 This guide requires that you have:
             %ul.check-list
               %li An Aptible account
               %li An SSH key associated with your Aptible user account
               %li The <a href="/support/toolbelt">Aptible Toolbelt</a> installed
 
-          -# - if quickstart? current_page.path
-          -#   %h2 Getting Started Guides
-          -#   %ul.nav--expandable
-          -#     -# - data.quickstart.each do |guide|
-          -#     -#   %li= guide.title
-          -#
-          -# TODO: Experiment. Get some feedback
-          - if @category_title
+          - if @language.articles.count > 1
+            .grid-aside__block
+              %h2= "Other #{@language.name} Quickstart Guides"
+              %ul.nav--expandable
+                - @language.articles.each do |article|
+                  - if !current_page.path.include? article.url
+                    %li
+                      %a{ href: "/support/quickstart/#{article.url}" }= article.framework
+
+        - if @category_title
+          .grid-aside__block
             %h2= @category_title
             %ul.nav--expandable
               - data.topics[@category_title].articles.each do |article|

--- a/source/stylesheets/_grid.scss
+++ b/source/stylesheets/_grid.scss
@@ -100,6 +100,11 @@ body {
   }
 }
 
+.grid--4up-center {
+  display: flex;
+  justify-content: center;
+}
+
 .grid-document {
   @include span-columns(9);
   float: left;

--- a/source/support/quickstart/category.haml
+++ b/source/support/quickstart/category.haml
@@ -10,24 +10,26 @@ header_subtitle: Step-by-step guides for getting started with Aptible
     }                                                                         |
 
 .content
-  .grid-container.grid--4up
-    - data.quickstart.each do |title, language|
-      %a.grid-item.card{ href: "/support/quickstart/#{language.url}", class: language.slug }
-        .card__header
-          %h3.card__title= title
-          .card__icon
-            = partial "images/icons/#{language.svg}"
-        .card__body= language.description
+  - if language
+    .grid-container.grid--single-center
+      .grid-item
+        %h2.heading--single-center
+          Which #{language.name} framework are you using?
 
-.documentation-main
-  %h3.sub-title Which #{language.name} framework are you using?
-  .container
-    .categories
-      .row
-        .category-wrapper{ class: "category-#{language.articles.count}" }
-          - language.articles.each do |article|
-            .col-xs-12.col-sm-4.col-md-3
-              %a.category-box{ href: "/support/quickstart/#{article.url}", class: article.slug }
-                .category-icon= partial "/images/icons/#{article.svg}"
-                .category-footer
-                  .category-title= article.framework
+    .grid-container.grid--4up.grid--4up-center
+      - language.articles.each do |article|
+        %a.grid-item.card{ href: "/support/quickstart/#{article.url}", class: article.slug }
+          .card__header
+            %h3.card__title= article.framework
+            .card__icon
+              = partial "images/icons/#{article.svg}"
+          .card__body= article.description
+  - else
+    .grid-container.grid--4up
+      - data.quickstart.each do |title, language|
+        %a.grid-item.card{ href: "/support/quickstart/#{quickstart_index_href(language)}", class: language.slug }
+          .card__header
+            %h3.card__title= title
+            .card__icon
+              = partial "images/icons/#{language.svg}"
+          .card__body= language.description

--- a/source/support/quickstart/index.haml
+++ b/source/support/quickstart/index.haml
@@ -14,7 +14,7 @@ layout: layout
 .content
   .grid-container.grid--4up
     - data.quickstart.each do |title, language|
-      %a.grid-item.card{ href: "/support/quickstart/#{language.url}", class: language.slug }
+      %a.grid-item.card{ href: quickstart_index_href(language), class: language.slug }
         .card__header
           %h3.card__title= title
           .card__icon


### PR DESCRIPTION
- Got the logic worked out for the breadcrumb nav and rendering language framework indexes when there are multiple framework articles for a language
<img width="1324" alt="screen shot 2016-09-26 at 11 33 15 pm" src="https://cloud.githubusercontent.com/assets/94830/18852644/a0bb4d80-8441-11e6-9f4f-e2e0694ec694.png">

- Put and "Other [Language] Frameworks" sidebar on the right, when there is one.
<img width="1326" alt="screen shot 2016-09-26 at 11 32 51 pm" src="https://cloud.githubusercontent.com/assets/94830/18852629/940824dc-8441-11e6-8680-620338e1fd6a.png">
