### PR TITLE
Fix empty posts when a non dymanic author page is built

### DIFF
--- a/source/blog/author.haml
+++ b/source/blog/author.haml
@@ -1,6 +1,7 @@
 ---
 layout: blog_posts.haml
 ---
+
 - content_for :header do
   %header.aptible-header.hero-gradient--angled
     = partial 'partials/main-nav', locals: {   |
@@ -8,6 +9,7 @@ layout: blog_posts.haml
         section_url: '/blog'                   |
       }                                        |
 
+- posts = posts || []
 - posts.each do |post|
   .blog-posts__post
     %a.blog-posts__link{ href: resource_link_path(post) }


### PR DESCRIPTION
@fancyremarker / @skylar: This is appears to be an issue with my understanding of setting up dynamic files. I was trying to avoid setting instance variables since those are  not available in the new version of middleman. 
https://github.com/aptible/www.aptible.com/blob/rebrand/config.rb#L82-L84

The author page I'm setting `posts` and an `author_id` for is built on its own and those are not set in that case. I'm not going to spend the time to dig in now, but if you see something, let me know.

![](http://www.mta.info/sites/default/files/archive/imgs/see_something_lg.png)