### PR TITLE
Make support search shippable

### DIFF
--- a/source/javascripts/search_page.coffee
+++ b/source/javascripts/search_page.coffee
@@ -1,30 +1,21 @@
 $(document).on 'turbolinks:load', ->
-  results = document.getElementById('st-results-large-container')
-  return unless results
+  $navSearch = $('.search-nav__input')
+  if $navSearch.length > 0
+    $navSearch.data 'query', $navSearch.val()
 
-  onHashChange = (e) ->
-    display = if window.location.hash.match(/stq=/) then 'block' else 'none'
-    results.style.display = display
+    updateTransitionClass = ->
+      $navSearch.val ''
+      if $navSearch.data('query') is ''
+        $navSearch.addClass('search-nav__input--with-transition');
+      else
+        $navSearch.removeClass('search-nav__input--with-transition');
 
-  window.addEventListener('hashchange', onHashChange)
-  onHashChange()
+    $navSearch.on 'change', ->
+      console.log $navSearch.val()
+      $navSearch.data 'query', $navSearch.val()
 
-  $('#st-results-large-container').delegate '.st-result', 'click', (e) ->
-    window.location.href = $(@).find('h3 a').attr('href')
+    $navSearch.on 'focus', ->
+      $navSearch.val $navSearch.data('query')
 
-  form = document.getElementById('search-form')
-  field = document.getElementById('st-default-search-input')
-
-  return unless form && field
-
-  $(form).on 'submit', (e) ->
-    e.preventDefault()
-    document.location.href = "/support/search/#stq=#{field.value}&stp=1"
-
-  # TODO: know when swiftype loads content
-  # debugger;
-  # $('a.st-prev').each ->
-  #   $(@).addClass('.arrow-link--left').text('Previous')
-  #
-  # $('a.st-next').each ->
-  #   $(@).addClass('.arrow-link--right').text('Next')
+    $navSearch.on 'blur', updateTransitionClass
+    updateTransitionClass()

--- a/source/partials/headers/_support-index.haml
+++ b/source/partials/headers/_support-index.haml
@@ -11,7 +11,7 @@
     - if current_page.data.header_search
       .search-bar
         %form#search-form.search-bar__form{ action: '/support/search/index.html', method: 'GET' }
-          %input#st-default-search-input.search-bar__input{             |
+          %input.st-default-search-input.search-bar__input{           |
             name: 'search',                                           |
             placeholder: 'Search all Topics and Quick Start Guides',  |
             type: 'text'                                              |

--- a/source/partials/support/_nav-items.haml
+++ b/source/partials/support/_nav-items.haml
@@ -9,5 +9,5 @@
 - unless current_page.data.header_search
   .nav-item.nav-item--search
     %form#search-form.search-nav__form{ action: '/support/search/index.html', method: 'GET' }
-      %input#st-default-search-input.search-nav__input{ type: 'search' }
+      %input.st-default-search-input.search-nav__input{ type: 'search' }
       = partial 'images/icons/search-loop.svg'

--- a/source/stylesheets/components/_search-bar.scss
+++ b/source/stylesheets/components/_search-bar.scss
@@ -1,6 +1,29 @@
 //
 // Support Header Search Bar
 //
+
+// Reset Swiftype input styles
+.aptible-www {
+  .st-ui-search-input,
+  .st-default-search-input {
+    background-clip: border-box;
+    background: $white 0 0 none;
+    border-radius: 5px;
+    border: none;
+    box-shadow: none;
+    box-sizing: border-box;
+    color: $light-blue-gray;
+    display: inline-block;
+    font-family: $base-font-family;
+    font-size: 14px;
+    font-weight: $regular;
+    height: auto;
+    line-height: 16px;
+    padding: 10px 35px 10px 12px;
+    width: 100%;
+  }
+}
+
 .search-bar {
   position: relative;
   width: 65%;
@@ -21,11 +44,12 @@
 .search-bar__input {
   background: $white;
   border: none;
+  box-shadow: none;
   color: $light-blue-gray;
   display: inline-block;
-  outline: none;
-  box-shadow: none;
+  font-size: $base-font-size;
   margin: 0;
+  outline: none;
   padding: 10px 35px 10px 12px;
   &::-webkit-input-placeholder {
     color: $sky-blue;
@@ -39,7 +63,7 @@
   padding: .5em .75em .5em .5em;
   position: absolute;
   right: 12px;
-  top: 14px;
+  top: 11px;
   transition: right, $base-duration, $base-timing;
   &::after {
     border-color: $sky-blue;
@@ -82,7 +106,7 @@
   }
 }
 
-.search-nav__input {
+.aptible-www .st-default-search-input.search-nav__input {
   background-color: transparent;
   border-radius: 0;
   border: none;
@@ -98,7 +122,6 @@
   outline: none;
   margin: 0;
   padding: 0;
-  transition: width $base-duration * 2 $base-timing;
   width: 20px;
   -webkit-appearance: none;
   &:focus, &[value] {
@@ -119,31 +142,39 @@
   }
 }
 
+.search-nav__input--with-transition {
+  transition: width $base-duration * 2 $base-timing;
+}
+
 //
 // Swiftype results
 //
-// The specificity required for swiftype css is... intense
-// See also _swiftype-results.scss
 .aptible-www {
-  .swiftype-widget {
-    .autocomplete {
+  div.st-default-autocomplete {
+    background-color: transparent;
+    box-shadow: none;
+    transform: translateY(8px);
+
+    .st-autocomplete-results {
+      background-color: $dark-blue;
+      background-image: none;
+      border-radius: 5px;
+    }
+
+    div.st-query-present {
       background-color: transparent;
-      box-shadow: none;
-      transform: translateY(8px);
+      box-sizing: border-box;
+      margin-top: 0;
 
-      ul {
-        background-color: $dark-blue;
-        background-image: none;
-        border-radius: 5px;
-      }
-
-      li {
+      a.st-ui-result {
         background-image: none;
         background-color: transparent;
-        border-bottom: none;
+        border-bottom: 1px solid $dark-blue-steel;
         border-radius: 0;
         border-top: none;
+        margin-bottom: 0;
         transition: all $base-duration $base-timing;
+
         &:first-child {
           border-top: none;
           border-top-right-radius: 5px;
@@ -155,49 +186,31 @@
           border-bottom-right-radius: 5px;
           border-bottom-left-radius: 5px;
         }
-        &.active {
-          background-color: rgba(0, 0, 0, .2);
+        &:hover, &:focus, &.active, &.st-keyboard-active-item {
+          background-color: rgba(255, 255, 255, .1);
           background-image: none;
-          border-bottom: none;
           border-top: none;
           box-shadow: none;
-          .title {
-            color: $white;
-            font-weight: $regular;
-            em {
-              color: $light-blue;
-              border-bottom: 1px dashed currentColor;
-              font-weight: $regular;
-            }
-          }
-          .sections {
-            color: $sky-blue;
-            em {
-              color: $sky-blue;
-              border-bottom: 1px dashed currentColor;
-              font-weight: $regular;
-            }
-          }
         }
-      }
-
-      .title {
-        color: $white;
-        font-weight: $regular;
-        line-height: 2;
-        em {
-          color: $light-blue;
-          border-bottom: 1px dashed currentColor;
+        .st-ui-type-heading {
+          color: $white !important;
+          font-size: 16px;
           font-weight: $regular;
+          line-height: 1.2;
         }
-      }
-
-      .sections {
-        color: $sky-blue;
-        em {
+        .st-ui-type-detail {
           color: $sky-blue;
-          border-bottom: 1px dashed currentColor;
-          font-weight: $regular;
+          font-size: 14px;
+          margin-bottom: 0;
+        }
+        .st-ui-type-detail,
+        .st-ui-type-heading {
+          em {
+            color: $light-blue;
+            background-color: transparent !important;
+            border-bottom: 1px dashed currentColor;
+            font-weight: $regular;
+          }
         }
       }
     }

--- a/source/stylesheets/components/_swiftype-results.scss
+++ b/source/stylesheets/components/_swiftype-results.scss
@@ -1,126 +1,162 @@
 //
 // swiftype Search Results (/support/search/index.html)
 //
-// The specificity required for swiftype css is... intense
-// See also _search-bar.scss
+// Results header summary
+.st-search-summary {
+  border-bottom: 1px solid #e9f1fd;
+  color: $light-blue-gray;
+  font-size: 16px;
+  font-weight: $regular;
+  margin-bottom: 50px;
+  padding-bottom: 1em;
+  text-align: right;
+}
+
+.st-ui-search-summary-query {
+  // color: $light-blue-gray;
+  // border-bottom: 1px dashed currentColor;
+  // font-style: normal;
+  // font-weight: $semibold;
+  // padding: 0 .2em;
+}
+
+// Search result
 .aptible-www {
-
-  div.swiftype {
-
-    div.st-result-listing {
-
-      div.st-search-summary {
-        border-bottom: 1px solid #e9f1fd;
-        margin-bottom: 50px;
-
-        h2 {
-          color: $light-blue-gray;
-          font-size: 16px;
-          font-weight: $regular;
-          padding-bottom: 1em;
-          text-align: right;
-
-          &::after {
-            display: none;
-          }
-
-          strong {
-            font-weight: $semibold;
-          }
-
-          .st-query {
-            color: $light-blue-gray;
-            border-bottom: 1px dashed currentColor;
-            font-style: normal;
-            font-weight: $semibold;
-            padding: 0 .2em;
-          }
-        }
-
-        &.no_results {
-          border-bottom: none;
-          h2 {
-            color: $dark-blue-steel;
-            font-size: 30px;
-            font-weight: $semibold;
-            font-style: italic;
-            letter-spacing: .08em;
-            margin-bottom: 20px;
-            padding-bottom: 0;
-            text-align: center;
-            .st-query {
-              color: $dark-blue-steel;
-              font-style: italic;
-            }
-          }
-          margin: 100px;
-        }
+  a.st-ui-result {
+    align-items: center;
+    display: inline-block;
+    font-family: $base-font-family;
+    justify-content: space-between;
+    border-bottom: 1px solid $light-blue;
+    margin-bottom: 30px;
+    position: relative;
+    width: 100%;
+    // &::before { display: none; }
+    &::before {
+      border-color: $blue;
+      border-radius: 2px;
+      border-style: solid;
+      border-width: 5px 5px 0 0;
+      content: '';
+      display: inline-block;
+      height: 15px;
+      position: absolute;
+      right: 0;
+      top: calc(50% - 15px);
+      transform: rotate(45deg);
+      transition: right $base-duration $base-timing;
+      width: 15px;
+    }
+    &:hover, &:focus {
+      outline: none;
+      .st-ui-type-detail,
+      .st-ui-type-detail-bold {
+        color: $light-blue-gray;
       }
-
-      div.st-result.with_image {
-        align-items: center;
-        cursor: pointer;
-        display: flex;
-        justify-content: space-between;
-        border-bottom: 1px solid $light-blue;
-        margin-bottom: 30px;
-        width: 100%;
-        &::after {
-          border-color: $blue;
-          border-radius: 2px;
-          border-style: solid;
-          border-width: 5px 5px 0 0;
-          content: '';
-          display: inline-block;
-          height: 15px;
-          position: relative;
-          top: -10px;
-          transform: rotate(45deg);
-          transition: transform $base-duration $base-timing;
-          width: 15px;
-        }
-        .st-result-image {
-          display: none;
-        }
-        div.st-result-text {
-          margin-left: 0;
-          max-width: calc(100% - 40px);
-
-          h3 {
-            color: $dark-blue-steel;
-            font-size: 30px;
-            font-weight: $semibold;
-            margin-bottom: 20px;
-            &::after { display: none; }
-            a {
-              color: $dark-blue-steel;
-            }
-          }
-        }
-
-        div.st-metadata {
-          margin-bottom: 30px;
-          // white-space: nowrap;
-          // overflow: hidden;
-          // text-overflow: ellipsis;
-
-          .st-snippet {
-            color: $light-blue-gray;
-            font-size: 24px;
-            font-weight: $light;
-
-            em {
-              border-bottom: 1px dashed currentColor;
-              font-style: normal;
-              font-weight: $regular;
-            }
-          }
-        }
+      &::before {
+        border-color: $blue;
+        right: -10px;
       }
+    }
+    &:last-of-type {
+      border-bottom: 1px solid $light-blue;
+    }
 
-      .st-pagination {
-        border-top: none;
-        text-align: right;
+    .st-ui-type-heading {
+      color: $dark-blue-steel !important;
+      font-size: 30px;
+      font-weight: $semibold;
+      overflow: visible;
+      margin-bottom: 20px;
+      text-overflow: inherit;
+      white-space: normal;
+      em {
+        background-color: transparent !important;
+        border-bottom: 1px dashed currentColor;
+      }
+    }
+    .st-ui-type-detail,
+    .st-ui-type-detail-bold {
+      color: $light-blue-gray;
+      font-size: 24px;
+      font-weight: $light;
+      margin-bottom: 30px;
+      max-height: 100px;
+      overflow: hidden;
+      text-overflow-multiline: ellipsis;
+      width: 80%;
+      em {
+        background-color: transparent !important;
+        border-bottom: 1px dashed currentColor;
+        font-weight: $regular;
+        padding: 0 0.2em;
+      }
+    }
+  }
+}
+
+
+// Pagination footer
+.st-ui-footer {
+  color: $light-blue-gray;
+  font-family: $base-font-family;
+  font-size: 16px;
+  font-weight: $regular;
+  margin-bottom: 50px;
+  padding-bottom: 1em;
+  text-align: right;
+}
+
+.st-result-pagination-link {
+  padding-left: 20px;
+  &:focus {
+    outline: none;
+  }
+}
+
+.st-ui-pagination-number-link {
+  &::before { display: none; }
+  &.active {
+    font-weight: $semibold;
+  }
+}
+
+.aptible-www {
+  .st-result-pagination-link {
+    &:hover, &:focus {
+      .st-ui-arrow.left-arrow::before {
+        transform: translate(-22px, -14px);
+      }
+    }
+    .st-ui-arrow.left-arrow {
+      border: none;
+      height: auto;
+      margin: 0;
+      transform: rotate(0);
+      width: auto;
+      &::before {
+        content: '←';
+        position: absolute;
+        transition: transform 0.25s ease-in-out;
+        transform: translate(-18px, -14px);
+      }
+    }
+    &:hover, &:focus {
+      .st-ui-arrow.right-arrow::after {
+        transform: translate(4px, -14px);
+      }
+    }
+    .st-ui-arrow.right-arrow {
+      border: none;
+      height: auto;
+      margin: 0;
+      transform: rotate(0);
+      width: auto;
+      &::after {
+        content: '→';
+        position: absolute;
+        transition: transform 0.25s ease-in-out;
+        transform: translate(0px, -14px);
       }
     }
   }

--- a/source/support/search.haml
+++ b/source/support/search.haml
@@ -10,7 +10,7 @@ title:  Search Aptible Support
 
 .content
   .grid-container
-    #st-results-large-container.blog-posts{:style => "display: block;"}
+    .st-search-container.blog-posts{:style => "display: block;"}
       = partial 'loading-indicator'
 
 = partial 'resources-footer'


### PR DESCRIPTION
Still some potential turbolinks related issues, but I’ll clean those up in a separate issue. This is ready to ship.

The nav bar search input gets janky because of the CSS transition, so there is some JS gymnastics to turn off that transition and empty the input.

Closes https://github.com/aptible/www.aptible.com/issues/271

![search](https://cloud.githubusercontent.com/assets/94830/19057276/f6849470-898b-11e6-82de-c2bbdd8c3a39.gif)
