### PR TITLE
Alb endpoints

### DIFF
--- a/data/topics.yml
+++ b/data/topics.yml
@@ -93,6 +93,8 @@
       url: "paas/how-to-download-database-backup"
     - title: "How does Aptible enforce memory limits?"
       url: "paas/memory-management-reference"
+    - title: "Upgrading to ALB Endpoints"
+      url: "paas/upgrading-to-alb-endpoints"
 
 "Aptible CLI":
   slug: "cli"

--- a/source/support/topics/paas/how-to-modify-nginx-config.md
+++ b/source/support/topics/paas/how-to-modify-nginx-config.md
@@ -1,21 +1,22 @@
 Aptible endpoints use [NGiNX proxies](https://github.com/aptible/docker-nginx) to terminate SSL for all requests. We offer a few ways to configure the way your app handles SSL by forwarding certain environment variables from your Aptible app configuration to the NGiNX proxies:
 
-* `FORCE_SSL`: By default, an Aptible app responds to both HTTP and HTTPS. Your
-  app can detect which protocol is being used by examining a request's
-  X-Forwarded-Proto header, which is set to "https" if HTTPS was used and unset
-  otherwise. If you wish to disallow HTTP entirely, you can set the
-  `FORCE_SSL` environment variable in your app's configuration. This will
-  redirect all HTTP traffic to HTTPS and set the
+* `FORCE_SSL`: By default, Aptible Endpoints direct traffic over both HTTP and
+  HTTPS. Your app can detect which protocol is being used by examining a
+  request's `X-Forwarded-Proto` header, which is set to "https" if HTTPS was
+  used and is unset otherwise. To disallow HTTP at the Aptible Endpoint
+  entirely, you can set the `FORCE_SSL` environment variable in your app's
+  configuration. This will cause your app's Endpoints to redirect all HTTP
+  traffic to HTTPS and set the
   [Strict-Transport-Security](https://www.owasp.org/index.php/HTTP_Strict_Transport_Security)
   header on responses with a max age of 1 year. Make sure you understand the
-  implications of setting the Strict-Transport-Security header before turning
-  this feature on. In particular, by design, clients that connect to your site
-  and receive this header will refuse to reconnect via HTTP for up to a year
-  after they receive the Strict-Transport-Security header.
+  implications of setting the Strict-Transport-Security header before using
+  this feature. In particular, by design, clients that connect to your site and
+  receive this header will refuse to reconnect via HTTP for up to a year after
+  they receive the Strict-Transport-Security header.
 
-* ([Legacy ELB Endpoints Only][0]) `DISABLE_WEAK_CIPHER_SUITES`: Aptible's
-  supported SSL protocols and cipher suites balance security and support for
-  older clients.  If you wish to target only modern clients, you can set the
+* ([Legacy ELB Endpoints Only][0]) `DISABLE_WEAK_CIPHER_SUITES`: The default
+  Aptible ELB Endpoint protocols and cipher suites balance security and support
+  for older clients. If you wish to target only modern clients, you can set the
   `DISABLE_WEAK_CIPHER_SUITES` environment variable to disable the SSLv3
   protocol and the RC4 cipher, both of which are otherwise allowed in the
   default configuration.
@@ -24,12 +25,12 @@ Aptible endpoints use [NGiNX proxies](https://github.com/aptible/docker-nginx) t
   `SSL_PROTOCOLS_OVERRIDE`: Users who need more control over the exact cipher
   suites and protocols offered by their servers can completely override the
   NGiNX `ssl_ciphers` and `ssl_protocols` directives by setting either or both
-  of these environment variables in their app configuration.  Please pay
-  careful attention to the documentation for both
+  of these environment variables in their app configuration. Please pay careful
+  attention to the documentation for both
   [`ssl_ciphers`](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_ciphers)
   and
   [`ssl_protocols`](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols)
-  when using these settings as syntax errors in these settings can keep your
+  when using these settings, as syntax errors in these settings can keep your
   NGiNX instance from starting.
 
 Setting these variables is a two-step process:

--- a/source/support/topics/paas/how-to-modify-nginx-config.md
+++ b/source/support/topics/paas/how-to-modify-nginx-config.md
@@ -13,18 +13,19 @@ Aptible endpoints use [NGiNX proxies](https://github.com/aptible/docker-nginx) t
   and receive this header will refuse to reconnect via HTTP for up to a year
   after they receive the Strict-Transport-Security header.
 
-* `DISABLE_WEAK_CIPHER_SUITES`: Aptible's supported SSL protocols and cipher
-  suites balance security and support for older clients. If you wish to target
-  only modern clients, you can set the `DISABLE_WEAK_CIPHER_SUITES`
-  environment variable to disable the SSLv3 protocol and the RC4 cipher, both
-  of which are otherwise allowed in the default configuration.
+* ([Legacy ELB Endpoints Only][0]) `DISABLE_WEAK_CIPHER_SUITES`: Aptible's
+  supported SSL protocols and cipher suites balance security and support for
+  older clients.  If you wish to target only modern clients, you can set the
+  `DISABLE_WEAK_CIPHER_SUITES` environment variable to disable the SSLv3
+  protocol and the RC4 cipher, both of which are otherwise allowed in the
+  default configuration.
 
-* `SSL_CIPHERS_OVERRIDE` and `SSL_PROTOCOLS_OVERRIDE`: Users who need more
-  control over the exact cipher suites and protocols offered by their servers
-  can completely override the NGiNX `ssl_ciphers` and `ssl_protocols`
-  directives by setting either or both of these environment variables in their
-  app configuration.
-  Please pay careful attention to the documentation for both
+* ([Legacy ELB Endpoints Only][0]) `SSL_CIPHERS_OVERRIDE` and
+  `SSL_PROTOCOLS_OVERRIDE`: Users who need more control over the exact cipher
+  suites and protocols offered by their servers can completely override the
+  NGiNX `ssl_ciphers` and `ssl_protocols` directives by setting either or both
+  of these environment variables in their app configuration.  Please pay
+  careful attention to the documentation for both
   [`ssl_ciphers`](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_ciphers)
   and
   [`ssl_protocols`](http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols)
@@ -52,3 +53,5 @@ aptible restart --app $APP_HANDLE
 aptible config:set DISABLE_WEAK_CIPHER_SUITES=true SSL_PROTOCOLS_OVERRIDE="TLSv1.1 TLSv1.2" --app $APP_HANDLE
 aptible restart --app $APP_HANDLE
 ```
+
+[0]: /support/topics/paas/upgrading-to-alb-endpoints

--- a/source/support/topics/paas/memory-management-reference.md
+++ b/source/support/topics/paas/memory-management-reference.md
@@ -4,6 +4,9 @@ notify you as a customer before enabling memory limits on your infrastructure).
 
 In the rest of this document, we'll refer to this feature as memory management.
 
+Note: this feature was presented on the Aptible Update Webinar of October 2016.
+[You can view the video presentation online.][0]
+
 
 # How does memory management work?
 
@@ -71,3 +74,5 @@ For app containers, you can update your memory limit via the Dashboard.
 For database containers, please contact support (increasing the memory
 footprint of a database involves downtime, and the Aptible team will work with
 you to coordinate a good timeframe).
+
+[0]: https://youtu.be/SIV0uPnz7i4?t=9m53s

--- a/source/support/topics/paas/upgrading-to-alb-endpoints.md
+++ b/source/support/topics/paas/upgrading-to-alb-endpoints.md
@@ -1,0 +1,136 @@
+ALB Endpoints are next-generation endpoints on Aptible. All customers are
+encouraged to upgrade legacy ELB Endpoints to ALB Endpoints.
+
+If you've provisioned an Endpoint recently, it might already be an ALB
+Endpoint. You can find out by looking at the reported platform in your
+Dashboard. Read on to understand how legacy ELB Endpoints and ALB Endpoints
+compare.
+
+Note: this feature was presented on the Aptible Update Webinar of October 2016.
+[You can view the video presentation online.][0]
+
+
+# Why Upgrade?
+
+ALB Endpoints are substantially more robust than ELB Endpoints. For example,
+when using an ALB Endpoint, you're essentially guaranteed that a failure during
+the deployment of your app cannot cause your app to go down, which
+unfortunately isn't the case with ELB Endpoints.
+
+ALB Endpoints also provide additional features, including:
+
+- **Connection Draining:** unlike ELB Endpoints, ALB Endpoints will drain
+  connections to existing instances over 30 seconds when you re-deploy your
+  app, which ensures that even long running requests aren't interrupted by a
+  deploy.
+- **DNS-Level Failover** to serve [your maintenance page][1], even if the
+  infrastructure hosting your app is down or unresponsive.
+- **HTTP 2 support:** ALBs let you better utilize high-latency network
+  connections via HTTP 2. Of course, HTTP 1 clients are supported, and your app
+  continues to receive traffic over HTTP 1.
+
+
+# Upgrade Checklist
+
+Besides increased reliability and new features, there are a few important
+differences between ELBs and ALBs that can affect you when you upgrade:
+
+
+## DNS Name
+
+If you have pointed DNS records at the DNS Name for your ELB, they'll stop
+working when you upgrade, because the ELB will be deleted.
+
+In most cases, this won't affect you, because the only DNS Name Aptible
+provides in the UI is a portable name that Aptible will autoamtically update
+when you upgrade to an ALB (this name looks like `elb-XXX-NNN.aptible.in`).
+
+If you've created a `CNAME` record in your DNS provider from your domain name
+to this this portable name, you're good.
+
+Likewise, if you're using DNSimple and created an ALIAS record to this portable
+name, or if you're using CloudFlare and are relying on CNAME flattening, you're
+still good.
+
+However, if you created a CNAME to the underlying ELB name (this one ends with
+`.elb.amazonaws.com`), or if you're using an `ALIAS` record in AWS Route 53,
+then you'll have to update your records to use the portable name before
+upgrade, or things will break.
+
+
+## HTTPS Protocols and Ciphers
+
+The default HTTPS configuration for ELB Endpoints is quite permissive, and
+supports SSLv3 and all versions of TLS, and you can use the environment
+variables `DISABLE_WEAK_CIPHER_SUITES`, `SSL_CIPHERS_OVERRIDE` and
+`SSL_PROTOCOLS_OVERRIDE` settings to customize it.
+
+However, on ALB Endpoints, the default is slightly different, and **you cannot
+modify it**. However, the default policy on ALB Endpoints is arguably superior,
+in the sense that it only supports TLS 1.0, TLS 1.1, and TLS 1.2 (i.e. it drops
+support for SSLv3). This is more-or-less equivalent to the configuration you'd
+get by setting `DISABLE_WEAK_CIPHER_SUITES` to `true`.
+
+Considering SSLv3 is widely regarded as insecure nowadays, we do encourage you
+to adopt the HTTPS configuration available on ALB Endpoints (or set
+`DISABLE_WEAK_CIPHER_SUITES` if you're not upgrading!).
+
+However, if you are relying on SSLv3 support (e.g. to support super-legacy
+clients), or conversely need to further restrict the protocols available on
+your endpoint (e.g. to remove TLS 1.0), you may not be able to upgrade.
+
+Note: if you'd like more detail as to exactly which ciphers are available in
+this HTTPS policy, you can use the AWS CLI to retrieve the policy:
+
+```
+aws elbv2 describe-ssl-policies --names ELBSecurityPolicy-2015-05
+```
+
+
+## X-Forwarded-For Header
+
+Unlike ELB Endpoints, ALB Endpoints perform SSL termination at the load
+balancer level. Traffic is then re-encrypted to be delivered to a reverse proxy
+on the same instance as your application container, which then forwards it over
+HTTP to your app.
+
+Both the ALB and the local reverse proxy will add an IP to the
+`X-Forwarded-For` header.  As a result, the X-Forwarded-For proxy will
+typically contain two IPs when using an ALB (whereas it would only contain one
+when using an ELB):
+
+- The IP of the client that connected to the ALB.
+- The IP of the ALB itself.
+
+Naturally, if you're using another proxy in front of your app (e.g. a CDN),
+there might more IPs in the list.
+
+In practice, most app frameworks will just use the first IP in the list (which
+will be the client IP here), but if your app is counting the number of IPs and
+matching it up to the number of proxies (which is a good practice if you're
+relying on this header for IP filtering), you'll need to account for one extra
+proxy.
+
+
+# How to upgrade
+
+## Upgrade by adding a new Endpoint
+
+This option is recommended for **production apps**.
+
+Provision a new Endpoint, and choose ALB as the platform. Once the Endpoint is
+provisioned, check that everything is behaving as expected, then update all DNS
+records pointing to the existing ELB Endpoint to use the new ALB Endpoint
+instead.
+
+## Upgrade in-place
+
+This option is recommended for **staging apps**.
+
+Navigate to your the list of Endpoints for your App, and follow the
+instructions to upgrade the Endpoint of your choice to ALB.
+
+
+[0]: https://youtu.be/SIV0uPnz7i4?t=17m34s
+[1]: /support/topics/paas/how/how-does-the-maintenance-page-url-config-setting-work
+[2]: /support/topics/paas/how-to-modify-nginx-config

--- a/source/support/topics/paas/upgrading-to-alb-endpoints.md
+++ b/source/support/topics/paas/upgrading-to-alb-endpoints.md
@@ -1,86 +1,80 @@
 ALB Endpoints are next-generation endpoints on Aptible. All customers are
 encouraged to upgrade legacy ELB Endpoints to ALB Endpoints.
 
-If you've provisioned an Endpoint recently, it might already be an ALB
-Endpoint. You can find out by looking at the reported platform in your
-Dashboard. Read on to understand how legacy ELB Endpoints and ALB Endpoints
-compare.
+If you have provisioned an Aptible Endpoint recently, it may already be an ALB
+Endpoint. You can check in the Aptible dashboard by selecting your app, then
+choosing the "Endpoints" tab to view all endpoints associated with that app.
+Each endpoint indicates the "platform" (ALB or ELB) the endpoint uses.
 
-Note: this feature was presented on the Aptible Update Webinar of October 2016.
-[You can view the video presentation online.][0]
+This article describes how legacy ELB Endpoints and ALB Endpoints differ, and
+how to upgrade. For more information on ALB Endpoints, watch the [October 2016
+Aptible Update Webinar][0].
 
 
 # Why Upgrade?
 
-ALB Endpoints are substantially more robust than ELB Endpoints. For example,
-when using an ALB Endpoint, you're essentially guaranteed that a failure during
-the deployment of your app cannot cause your app to go down, which
-unfortunately isn't the case with ELB Endpoints.
+ALB Endpoints are more robust than ELB Endpoints and provide additional
+features, including:
 
-ALB Endpoints also provide additional features, including:
-
-- **Connection Draining:** unlike ELB Endpoints, ALB Endpoints will drain
-  connections to existing instances over 30 seconds when you re-deploy your
+- **Connection Draining:** Unlike ELB Endpoints, ALB Endpoints will drain
+  connections to existing instances over 30 seconds when you redeploy your
   app, which ensures that even long running requests aren't interrupted by a
   deploy.
-- **DNS-Level Failover** to serve [your maintenance page][1], even if the
+- **DNS-Level Failover:** Serves [your maintenance page][1], even if the
   infrastructure hosting your app is down or unresponsive.
-- **HTTP 2 support:** ALBs let you better utilize high-latency network
-  connections via HTTP 2. Of course, HTTP 1 clients are supported, and your app
+- **HTTP/2 Support:** ALBs let you better utilize high-latency network
+  connections via HTTP/2. HTTP 1 clients are still supported, and your app
   continues to receive traffic over HTTP 1.
 
 
 # Upgrade Checklist
 
-Besides increased reliability and new features, there are a few important
-differences between ELBs and ALBs that can affect you when you upgrade:
+When planning an upgrade from an ELB Endpoint to an ALB Endpoint, be aware of a
+few key differences between the platforms:
 
 
 ## DNS Name
 
-If you have pointed DNS records at the DNS Name for your ELB, they'll stop
-working when you upgrade, because the ELB will be deleted.
+If you pointed your DNS records directly at the AWS DNS name for your ELB, DNS
+will break when you upgrade, because the underlying AWS ELB will be deleted.
 
-In most cases, this won't affect you, because the only DNS Name Aptible
-provides in the UI is a portable name that Aptible will autoamtically update
-when you upgrade to an ALB (this name looks like `elb-XXX-NNN.aptible.in`).
+If you pointed your DNS records at the Aptible portable name
+(`elb-XXX-NNN.aptible.in`), you will not need to modify your DNS, as the
+Aptible record will automatically update. This means you will not need to
+change your DNS records if:
 
-If you've created a `CNAME` record in your DNS provider from your domain name
-to this this portable name, you're good.
+- You created a `CNAME` record in your DNS provider from your domain name to
+  this this portable name, or
+- You are using DNSimple and created an ALIAS record to the Aptible portable
+name, or if you're using CloudFlare and are relying on CNAME flattening.
 
-Likewise, if you're using DNSimple and created an ALIAS record to this portable
-name, or if you're using CloudFlare and are relying on CNAME flattening, you're
-still good.
-
-However, if you created a CNAME to the underlying ELB name (this one ends with
-`.elb.amazonaws.com`), or if you're using an `ALIAS` record in AWS Route 53,
-then you'll have to update your records to use the portable name before
-upgrade, or things will break.
+However, if you created a CNAME to the underlying ELB name (ending with
+`.elb.amazonaws.com`), or if you are using an `ALIAS` record in AWS Route 53,
+then you must update your DNS records to use the Aptible portable name before
+upgrading.
 
 
 ## HTTPS Protocols and Ciphers
 
-The default HTTPS configuration for ELB Endpoints is quite permissive, and
-supports SSLv3 and all versions of TLS, and you can use the environment
+The default HTTPS configuration for ELB Endpoints is quite permissive, supports
+SSLv3 and all versions of TLS, and can be customized using the environment
 variables `DISABLE_WEAK_CIPHER_SUITES`, `SSL_CIPHERS_OVERRIDE` and
-`SSL_PROTOCOLS_OVERRIDE` settings to customize it.
+`SSL_PROTOCOLS_OVERRIDE`.
 
-However, on ALB Endpoints, the default is slightly different, and **you cannot
-modify it**. However, the default policy on ALB Endpoints is arguably superior,
-in the sense that it only supports TLS 1.0, TLS 1.1, and TLS 1.2 (i.e. it drops
-support for SSLv3). This is more-or-less equivalent to the configuration you'd
-get by setting `DISABLE_WEAK_CIPHER_SUITES` to `true`.
+ALB Endpoints have different configurations and **cannot be modified**. For
+most customers, the default HTTPS configuration for ALB Endpoints is an ideal
+balance between security and compatability. The default ALB Endpoint
+configuration supports TLS 1.0, TLS 1.1, and TLS 1.2, but not SSLv3. This is
+roughly equivalent to the ELB Endpoint configuration that results when you set
+`DISABLE_WEAK_CIPHER_SUITES=true`.
 
-Considering SSLv3 is widely regarded as insecure nowadays, we do encourage you
-to adopt the HTTPS configuration available on ALB Endpoints (or set
-`DISABLE_WEAK_CIPHER_SUITES` if you're not upgrading!).
+If you require SSLv3 support, or conversely need to further restrict the
+protocols available on your endpoint (e.g. to remove TLS 1.0), you should use
+an ELB Endpoint.
 
-However, if you are relying on SSLv3 support (e.g. to support super-legacy
-clients), or conversely need to further restrict the protocols available on
-your endpoint (e.g. to remove TLS 1.0), you may not be able to upgrade.
-
-Note: if you'd like more detail as to exactly which ciphers are available in
-this HTTPS policy, you can use the AWS CLI to retrieve the policy:
+Note: If you would like more detail as to exactly which ciphers are available
+in the default ALB Endpoint HTTPS policy, you can use the AWS CLI to retrieve
+the policy:
 
 ```
 aws elbv2 describe-ssl-policies --names ELBSecurityPolicy-2015-05
@@ -89,46 +83,44 @@ aws elbv2 describe-ssl-policies --names ELBSecurityPolicy-2015-05
 
 ## X-Forwarded-For Header
 
-Unlike ELB Endpoints, ALB Endpoints perform SSL termination at the load
-balancer level. Traffic is then re-encrypted to be delivered to a reverse proxy
-on the same instance as your application container, which then forwards it over
-HTTP to your app.
+Unlike ELB Endpoints, ALB Endpoints perform SSL/TLS termination at the load
+balancer level. Traffic is then re-encrypted, delivered to a reverse proxy on
+the same instance as your app container, and forwarded over HTTP to your app.
 
-Both the ALB and the local reverse proxy will add an IP to the
-`X-Forwarded-For` header.  As a result, the X-Forwarded-For proxy will
-typically contain two IPs when using an ALB (whereas it would only contain one
+Both the ALB and the local reverse proxy will add an IP address to the
+`X-Forwarded-For` header. As a result, the X-Forwarded-For proxy will typically
+contain two IP addresses when using an ALB (whereas it would only contain one
 when using an ELB):
 
-- The IP of the client that connected to the ALB.
-- The IP of the ALB itself.
+1. The IP address of the client that connected to the ALB
+2. The IP address of the ALB itself
 
-Naturally, if you're using another proxy in front of your app (e.g. a CDN),
-there might more IPs in the list.
+If you are using another proxy in front of your app (e.g. a CDN), there might
+more IP addresses in the list. If your app contains logic that depends on this
+header (e.g., IP address filtering, or matching header entries to proxies) you
+will want to account for the additional proxy.
 
-In practice, most app frameworks will just use the first IP in the list (which
-will be the client IP here), but if your app is counting the number of IPs and
-matching it up to the number of proxies (which is a good practice if you're
-relying on this header for IP filtering), you'll need to account for one extra
-proxy.
+# How to Upgrade
 
-
-# How to upgrade
-
-## Upgrade by adding a new Endpoint
+## Upgrade by Adding a New Endpoint
 
 This option is recommended for **production apps**.
 
-Provision a new Endpoint, and choose ALB as the platform. Once the Endpoint is
-provisioned, check that everything is behaving as expected, then update all DNS
-records pointing to the existing ELB Endpoint to use the new ALB Endpoint
-instead.
+1. Provision a new Endpoint, choosing ALB as the platform
+2. Once the new ALB Endpoint is provisioned, verify that your app is behaving
+   properly when using the new ALB's Aptible portable name
+   (`elb-XXX-NNN.aptible.in`)
+3. Update all DNS records pointing to the old ELB Endpoint to use the new ALB
+   Endpoint instead
+4. Deprovision the old ELB Endpoint
 
-## Upgrade in-place
+## Upgrade In-place
 
 This option is recommended for **staging apps**.
 
-Navigate to your the list of Endpoints for your App, and follow the
-instructions to upgrade the Endpoint of your choice to ALB.
+In the Aptible dashboard, locate the ELB Endpoint you want to upgrade. Select
+"Upgrade" under the "Platform" entry. Custom upgrade instructions for that
+specific endpoint will appear.
 
 
 [0]: https://youtu.be/SIV0uPnz7i4?t=17m34s


### PR DESCRIPTION
This adds documentation for ALB Endpoints. There are a few things that need to happen to "officially" release this feature:
- [x] Merge and deploy https://github.com/aptible/sweetness/pull/670
- [ ] Publish this.
- [ ] Expose a Platform selector in the Dashboard, defaulting to ALB (https://github.com/aptible/dashboard.aptible.com/pull/765)
- [ ] Expose the ability to upgrade an ELB to ALB via the Dashboard (https://github.com/aptible/dashboard.aptible.com/pull/765).

cc @fancyremarker 
