### PR TITLE
Canonical URLs

### DIFF
--- a/source/customers/index.haml
+++ b/source/customers/index.haml
@@ -28,7 +28,7 @@ title: Aptible Customers
           Built on Amazon Web Services, Aptible’s secure, compliant cloud
           platform allowed UCSF to launch The Pride Study in less than 6 weeks,
           for 90% less than the cost of a traditional IT solution.
-        %a.btn.btn--outline.btn--outline--white{ href: '/customers/ucsf-pride-study', data: { turbolinks: "false" }}
+        %a.btn.btn--outline.btn--outline--white{ href: '/customers/ucsf-pride-study/', data: { turbolinks: "false" }}
           Read the full story
 
       .grid-item.case-study.case-study--telepharm
@@ -39,7 +39,7 @@ title: Aptible Customers
           "Working with Aptible has effectively extended our dev team. We now
           have a group of world-class DevOps ensuring the reliability and
           scalability of our app."
-        %a.btn.btn--outline.btn--outline--white{ href: '/customers/telepharm', data: { turbolinks: "false" }}
+        %a.btn.btn--outline.btn--outline--white{ href: '/customers/telepharm/', data: { turbolinks: "false" }}
           Read the full story
 
   .grid-container.grid--single-center

--- a/source/enclave.haml
+++ b/source/enclave.haml
@@ -18,7 +18,7 @@ description: Aptible Enclave is a container platform that simplifies secure
 
         %p.heading__summary--light-blue
           %a.btn{ href: open_account_href } Open a Development Account
-          %a.btn.btn--outline{ href: '/pricing' } See Pricing
+          %a.btn.btn--outline{ href: '/pricing/' } See Pricing
 
       .grid-item.product-page__enclave
         = partial '/images/enclave.svg'

--- a/source/feed.xml.builder
+++ b/source/feed.xml.builder
@@ -4,7 +4,7 @@ xml.feed xmlns: 'http://www.w3.org/2005/Atom' do
   xml.subtitle 'Posts detailing feature updates, compliance resources, and information useful to users of Aptible\'s security and DevOps tools.'
   xml.id 'https://www.aptible.com/blog'
   xml.link rel: 'alternate', type: 'text/html', hreflang: 'en', href: 'https://www.aptible.com/'
-  xml.link href: 'https://www.aptible.com/blog'
+  xml.link href: 'https://www.aptible.com/blog/'
   xml.link href: 'https://www.aptible.com/feed.xml', rel: 'self'
   xml.updated latest_blog_post.data.posted.to_time.iso8601
   xml.author { xml.name 'Aptible Blog RSS' }

--- a/source/gridiron.haml
+++ b/source/gridiron.haml
@@ -18,7 +18,7 @@ description: Aptible Gridiron helps engineering teams set up and run robust
 
         %p.heading__summary--light-blue
           %a.btn{ href: open_account_href } Open a Development Account
-          %a.btn.btn--outline{ href: '/pricing' } See Pricing
+          %a.btn.btn--outline{ href: '/pricing/' } See Pricing
 
       .grid-item.product-page__gridiron
         = partial '/images/gridiron.svg'

--- a/source/index.haml
+++ b/source/index.haml
@@ -24,7 +24,7 @@ description: Powerful security and DevOps tools for engineering teams.
           deployment into private AWS environments. Fast, efficient
           engineering teams use Enclave to secure their most important
           architecture.
-        %a.btn{ href: '/enclave' } Learn more about Enclave
+        %a.btn{ href: '/enclave/' } Learn more about Enclave
 
       .gridiron-home-hero.product-hero.grid-item
         .gridiron-home-hero__illustration.product-hero__illustration
@@ -37,7 +37,7 @@ description: Powerful security and DevOps tools for engineering teams.
           Aptible Gridiron helps software engineering teams stand up and
           scale agile information security programs. Gridiron makes
           compliance with complex regulations like HIPAA fast and easy.
-        %a.btn{ href: '/gridiron' } Learn more about Gridiron
+        %a.btn{ href: '/gridiron/' } Learn more about Gridiron
 
 .content
   .grid-container.grid-container--ruled.grid--single-center
@@ -48,7 +48,7 @@ description: Powerful security and DevOps tools for engineering teams.
       %p.summary--single-center
         Try Enclave today with $500 free credit
 
-      %a.btn{ href: '/pricing' } See Pricing & Plans
+      %a.btn{ href: '/pricing/' } See Pricing & Plans
 
   .healthcare-systems.grid-container.grid--2up.grid--2up-flex.grid-container--ruled
     .grid-item

--- a/source/layouts/blog_post.haml
+++ b/source/layouts/blog_post.haml
@@ -24,7 +24,7 @@
     .grid-container
       %nav.blog-posts__nav
         .blog-posts__link--footer
-          %a.blog-posts__link--all{ href: '/blog' }
+          %a.blog-posts__link--all{ href: '/blog/' }
             %span.post__title All Posts
         - if prev_post
           %a.blog-posts__link--footer.blog-posts__link--prev{ href: prev_post.url }

--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -2,6 +2,7 @@
 %html
   %head
     %title= page_title
+    %link{ rel: 'cononical', href: page_url }
     %meta.swiftype{ name: "title", "data-type" => "string", content: page_title }/
     %meta{ property: "og:title", content: page_title }/
     %meta{ property: "og:description", content: page_description }/

--- a/source/layouts/support-document.haml
+++ b/source/layouts/support-document.haml
@@ -59,6 +59,6 @@
           - if defined? @category_title
             %a.arrow-link--left{ href: @category_url } Back to #{@category_title}
           - elsif quickstart? current_page.path
-            %a.arrow-link--left{ href: '/support/quickstart' } Back to quickstart guides
+            %a.arrow-link--left{ href: '/support/quickstart/' } Back to quickstart guides
           - else
-            %a.arrow-link--left{ href: '/support/topics' } Back to support topics
+            %a.arrow-link--left{ href: '/support/topics/' } Back to support topics

--- a/source/partials/_nav-items.haml
+++ b/source/partials/_nav-items.haml
@@ -1,27 +1,27 @@
-%a.nav-item{ href: '/enclave', class: active_nav_item('enclave') } Enclave
-%a.nav-item{ href: '/gridiron', class: active_nav_item('gridiron') } Gridiron
-%a.nav-item{ href: '/pricing', class: active_nav_item('pricing') } Pricing
+%a.nav-item{ href: '/enclave/', class: active_nav_item('enclave') } Enclave
+%a.nav-item{ href: '/gridiron/', class: active_nav_item('gridiron') } Gridiron
+%a.nav-item{ href: '/pricing/', class: active_nav_item('pricing') } Pricing
 
-%a.nav-item{ href: '/customers' } Customers
+%a.nav-item{ href: '/customers/' } Customers
 -# TODO: When we get back to customer pages...
 -# .nav-item.nav-parent{ tabindex: 0 }
--#   %a.nav-item.nav-item--parent{ href: '/customers' } Customers
+-#   %a.nav-item.nav-item--parent{ href: '/customers/' } Customers
 -#   %nav.nav-list__child-nav
--#     %a.nav-item{ href: '/ceo' } CEOs
--#     %a.nav-item{ href: '/cto' } CTOs
--#     %a.nav-item{ href: '/securty-professional' } Security Professionals
--#     %a.nav-item{ href: '/compliance-professional' } Compliance Professionals
--#     %a.nav-item{ href: '/case-studies' } Case Studies
+-#     %a.nav-item{ href: '/ceo/' } CEOs
+-#     %a.nav-item{ href: '/cto/' } CTOs
+-#     %a.nav-item{ href: '/securty-professional/' } Security Professionals
+-#     %a.nav-item{ href: '/compliance-professional/' } Compliance Professionals
+-#     %a.nav-item{ href: '/case-studies/' } Case Studies
 
 .nav-item.nav-parent{ tabindex: 0 }
-  %a.nav-item.nav-item--parent{ href: '/support', class: active_nav_item('support') } Help
+  %a.nav-item.nav-item--parent{ href: '/support/', class: active_nav_item('support') } Help
   %nav.nav-list__child-nav
-    -# %a.nav-item{ href: '/resources' } Resources
-    %a.nav-item{ href: '/support/topics' } Support Topics
-    %a.nav-item{ href: '/support/quickstart' } Quickstart Guides
+    -# %a.nav-item{ href: '/resources/' } Resources
+    %a.nav-item{ href: '/support/topics/' } Support Topics
+    %a.nav-item{ href: '/support/quickstart/' } Quickstart Guides
     %a.nav-item{ href: contact_href } Open a Ticket
-    %a.nav-item{ href: '/legal' } Legal
-    %a.nav-item{ href: '/faq' } FAQ
+    %a.nav-item{ href: '/legal/' } Legal
+    %a.nav-item{ href: '/faq/' } FAQ
 
 .nav--dashboard-auth
   %a.nav-item{ href: dashboard_href } Login

--- a/source/partials/_ui-kit-header.haml
+++ b/source/partials/_ui-kit-header.haml
@@ -5,7 +5,7 @@
       .nav-list--left
         %a{ href: '/' }= partial 'partials/aptible-mark'
         %h2.aptible-mark__title
-          %a{ href: '/ui-kit' } UI Kit
+          %a{ href: '/ui-kit/' } UI Kit
 
       %nav.nav-list.nav-list--center
         %a.nav-toggle

--- a/source/partials/headers/_login-signup.haml
+++ b/source/partials/headers/_login-signup.haml
@@ -1,2 +1,2 @@
 %a.nav-item{ href: dashboard_href } Login
-%a.nav-item.btn{ href: '/pricing'} Sign Up
+%a.nav-item.btn{ href: '/pricing/'} Sign Up

--- a/source/partials/support/_nav-items.haml
+++ b/source/partials/support/_nav-items.haml
@@ -1,10 +1,10 @@
-%a.nav-item{ class: active_nav_item('quickstart'), href: '/support/quickstart' } Quickstart Guides
-%a.nav-item{ class: active_nav_item('toolbelt'), href: '/support/toolbelt' } Toolbelt
-%a.nav-item{ class: active_nav_item('topics'), href: '/support/topics' } Topics
+%a.nav-item{ class: active_nav_item('quickstart'), href: '/support/quickstart/' } Quickstart Guides
+%a.nav-item{ class: active_nav_item('toolbelt'), href: '/support/toolbelt/' } Toolbelt
+%a.nav-item{ class: active_nav_item('topics'), href: '/support/topics/' } Topics
 
 .nav--dashboard-auth
   %a.nav-item{ href: dashboard_href } Login
-  %a.nav-item{ href: '/pricing'} Sign Up
+  %a.nav-item{ href: '/pricing/'} Sign Up
 
 - unless current_page.data.header_search
   .nav-item.nav-item--search

--- a/source/pricing.haml
+++ b/source/pricing.haml
@@ -161,4 +161,4 @@ description: "Aptible plans and pricing"
         %img.support-pricing-tier__slack{ src: '/images/slack.svg' }
 
     .grid-container--bordered__tray.gri-item
-      %a.btn{ href: '/support-plans' } Learn More About Support
+      %a.btn{ href: '/support-plans/' } Learn More About Support

--- a/source/resources/index.haml
+++ b/source/resources/index.haml
@@ -2,7 +2,7 @@
   %header.aptible-header.aptible-header--with-breadcrumbs.hero-gradient--angled
     = partial 'partials/main-nav', locals: {      |
         section_title: 'Resources',               |
-        section_url: '/resources'                 |
+        section_url: '/resources/'                |
       }                                           |
 
 .filter-state
@@ -26,7 +26,7 @@
       .grid-aside__block.grid-aside__block--segment
         %h3 From the Blog
         %p= lorem.words 15
-        %a.arrow-link--right{ href: '/blog' } View the blog
+        %a.arrow-link--right{ href: '/blog/' } View the blog
 
       - posts = blog_posts_newest_first
       - posts.take(3).each do |post|

--- a/source/ui-kit/navigation.haml
+++ b/source/ui-kit/navigation.haml
@@ -94,9 +94,9 @@ title: 'Navigation'
   .grid-container
     %h2 Back / Forward Links
     %p
-      %a.arrow-link--left{ href: '/support/quickstart' } Arrow Link Left
+      %a.arrow-link--left{ href: '/support/quickstart/' } Arrow Link Left
       &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-      %a.arrow-link--right{ href: '/support/quickstart' } Arrow Link Right
+      %a.arrow-link--right{ href: '/support/quickstart/' } Arrow Link Right
 
     %pre.highlight.plaintext
       %code


### PR DESCRIPTION
@sandersonet and @shahkader identified some descrepancies in google analytics after the rebrand. I'd linked to internal pages, like `/pricing/index.html` with `/pricing` and we had been referencing `/pricing/` in analytics. Google notes this also hurts our search rank. Referenced: https://support.google.com/webmasters/answer/139066?hl=en

This chagne adds a canonical URL `link` to the page `head` and explicitly links to internal  hrefs with a trailing slash: `href=“/support/quickstart/“`
