### PR TITLE
Major Typo for the canonical links (.___ .)

### DIFF
--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -2,7 +2,7 @@
 %html
   %head
     %title= page_title
-    %link{ rel: 'cononical', href: page_url }
+    %link{ rel: 'canonical', href: page_url }
     %meta.swiftype{ name: "title", "data-type" => "string", content: page_title }/
     %meta{ property: "og:title", content: page_title }/
     %meta{ property: "og:description", content: page_description }/


### PR DESCRIPTION
Thanks for catching @sandersonet 