### PR TITLE
Clarify TRTs in wall hours, not business hours

### DIFF
--- a/source/support-plans.haml
+++ b/source/support-plans.haml
@@ -126,10 +126,10 @@ description: "Aptible support plans and pricing"
             %tr
               %td
                 .support-severity__segment__label Target Response Time
-                .support-severity__segment__value < 24 hours
+                .support-severity__segment__value < 48 hours
               %td
                 .support-severity__segment__label Target Response Time
-                .support-severity__segment__value < 12 hours
+                .support-severity__segment__value < 24 hours
               %td
                 .support-severity__segment__label Target Response Time
                 .support-severity__segment__value < 6 hours

--- a/source/support-plans.haml
+++ b/source/support-plans.haml
@@ -170,10 +170,10 @@ description: "Aptible support plans and pricing"
             %tr
               %td
                 .support-severity__segment__label Support Hours
-                .support-severity__segment__value 9am-6pm Eastern
+                .support-severity__segment__value 24/7
               %td
                 .support-severity__segment__label Support Hours
-                .support-severity__segment__value 9am-6pm Eastern
+                .support-severity__segment__value 24/7
               %td
                 .support-severity__segment__label Support Hours
                 .support-severity__segment__value 24/7

--- a/source/support-plans.haml
+++ b/source/support-plans.haml
@@ -126,10 +126,10 @@ description: "Aptible support plans and pricing"
             %tr
               %td
                 .support-severity__segment__label Target Response Time
-                .support-severity__segment__value < 48 hours
+                .support-severity__segment__value < 24 business hours
               %td
                 .support-severity__segment__label Target Response Time
-                .support-severity__segment__value < 24 hours
+                .support-severity__segment__value < 12 business hours
               %td
                 .support-severity__segment__label Target Response Time
                 .support-severity__segment__value < 6 hours
@@ -170,10 +170,10 @@ description: "Aptible support plans and pricing"
             %tr
               %td
                 .support-severity__segment__label Support Hours
-                .support-severity__segment__value 24/7
+                .support-severity__segment__value 9am-6pm Eastern, M-F
               %td
                 .support-severity__segment__label Support Hours
-                .support-severity__segment__value 24/7
+                .support-severity__segment__value 9am-6pm Eastern, M-F
               %td
                 .support-severity__segment__label Support Hours
                 .support-severity__segment__value 24/7


### PR DESCRIPTION
Our Target Response Times have always been implemented in terms of business hours, not wall hours. However, that was never clearly stated (and it's also convoluted for customers to think of response times in terms of business hours). So, I've opted to use wall hour values that more closely approximate the business hour targets.