### PR TITLE
Update support article data attributes for Swiftype

### DIFF
--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -40,7 +40,7 @@
 
     = stylesheet_link_tag :all
 
-  %body.aptible-www{ class: page_classes, data: { swiftype: { name: 'body', type: 'text', index: 'true' } } }
+  %body.aptible-www{ class: page_classes, "data-swiftype-index" => "false" }
     = yield_content :header
 
     = yield

--- a/source/layouts/support-document.haml
+++ b/source/layouts/support-document.haml
@@ -21,11 +21,11 @@
         %span.nav-item--separator
         %a.nav-item{:href => ''}= @title || title
 
-  .content
+  .content{"data-swiftype-name" => "body", "data-swiftype-type" => "text", "data-swiftype-index" => "true" }
     .grid-container.quickstart
       %h1.document-title= @title || title
 
-      .grid-aside
+      .grid-aside{ "data-swiftype-index" => "false" }
         - if quickstart? current_page.path
           .grid-aside__block
             %h2 This guide requires that you have:

--- a/source/stylesheets/components/_swiftype-results.scss
+++ b/source/stylesheets/components/_swiftype-results.scss
@@ -64,7 +64,7 @@
 
     .st-ui-type-heading {
       color: $dark-blue-steel !important;
-      font-size: 30px;
+      font-size: modular-scale(1);
       font-weight: $semibold;
       overflow: visible;
       margin-bottom: 20px;
@@ -78,7 +78,7 @@
     .st-ui-type-detail,
     .st-ui-type-detail-bold {
       color: $light-blue-gray;
-      font-size: 24px;
+      font-size: 18px;
       font-weight: $light;
       margin-bottom: 30px;
       max-height: 100px;


### PR DESCRIPTION
Right now, the entire content of the <body> section is being indexed in Swiftype as the "body" property, which is used in result summaries:

![screenshot 2016-12-03 19 27 23](https://cloud.githubusercontent.com/assets/3422584/20863644/95a4d506-b98e-11e6-9cb6-a5486d499bb8.png)

This PR updates our Swiftype meta tags to:

1. Exclude all body elements of any page by default
2. For support documents only, index the document content; exclude asides

@gib @sandersonet 