### PR TITLE
Add support articles and CFN template for apexes

### DIFF
--- a/data/topics.yml
+++ b/data/topics.yml
@@ -98,6 +98,10 @@
       url: "enclave/upgrading-to-alb-endpoints"
     - title: "How do I deploy a private Docker image?"
       url: "enclave/how-to-deploy-from-private-repository"
+    - title: "How do I use my domain apex on Aptible?"
+      url: "enclave/how-do-i-use-my-domain-apex-on-aptible"
+    - title: "How do I set up an apex redirect using AWS?"
+      url: "enclave/how-do-i-setup-an-apex-redirect-using-aws"
 
 "The Aptible CLI":
   header: "Using Enclave from the command line"

--- a/source/assets/cloudformation-redirect.json
+++ b/source/assets/cloudformation-redirect.json
@@ -1,0 +1,123 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Outputs": {
+        "DistributionHostname": {
+            "Description": "Use this domain name in your DNS provider.",
+            "Value": {
+                "Fn::GetAtt": [
+                    "RootDistribution",
+                    "DomainName"
+                ]
+            }
+        }
+    },
+    "Parameters": {
+        "Domain": {
+            "Description": "Root domain for your website, which you want to redirect from (e.g.: example.com)",
+            "Type": "String"
+        },
+        "Subdomain": {
+            "Default": "www",
+            "Description": "Subdomain for your app hosted on Aptible, which you want to redirect to (e.g.: www)",
+            "Type": "String"
+        },
+        "ViewerBucketName": {
+            "AllowedPattern": "^[^.]+$",
+            "ConstraintDescription": "must not contain dots",
+            "Description": "A name for the S3 bucket that will host your static redirect. The only requirement for this name is to be unique and not contain dots. End-users will never see it.",
+            "Type": "String"
+        }
+    },
+    "Resources": {
+        "RootBucket": {
+            "Properties": {
+                "AccessControl": "PublicRead",
+                "BucketName": {
+                    "Ref": "ViewerBucketName"
+                },
+                "WebsiteConfiguration": {
+                    "RedirectAllRequestsTo": {
+                        "HostName": {
+                            "Fn::Join": [
+                                "",
+                                [
+                                    {
+                                        "Ref": "Subdomain"
+                                    },
+                                    ".",
+                                    {
+                                        "Ref": "Domain"
+                                    }
+                                ]
+                            ]
+                        },
+                        "Protocol": "https"
+                    }
+                }
+            },
+            "Type": "AWS::S3::Bucket"
+        },
+        "RootCertificate": {
+            "Properties": {
+                "DomainName": {
+                    "Ref": "Domain"
+                }
+            },
+            "Type": "AWS::CertificateManager::Certificate"
+        },
+        "RootDistribution": {
+            "Properties": {
+                "DistributionConfig": {
+                    "Aliases": [
+                        {
+                            "Ref": "Domain"
+                        }
+                    ],
+                    "DefaultCacheBehavior": {
+                        "ForwardedValues": {
+                            "QueryString": true
+                        },
+                        "MinTTL": "0",
+                        "MaxTTL": "3600",
+                        "DefaultTTL": "3600",
+                        "SmoothStreaming": false,
+                        "TargetOriginId": {
+                          "Ref": "RootBucket"
+                        },
+                        "ViewerProtocolPolicy": "allow-all"
+                    },
+                    "Enabled": true,
+                    "Origins": [
+                        {
+                            "CustomOriginConfig": {
+                                "OriginProtocolPolicy": "http-only"
+                            },
+                            "DomainName": {
+                              "Fn::Join": [
+                                "",
+                                [
+                                  { "Ref": "RootBucket" },
+                                  ".s3-website-",
+                                  { "Ref" : "AWS::Region" },
+                                  ".amazonaws.com"
+                                ]
+                              ]
+                            },
+                            "Id": {
+                              "Ref": "RootBucket"
+                            }
+                        }
+                    ],
+                    "PriceClass": "PriceClass_100",
+                    "ViewerCertificate": {
+                        "AcmCertificateArn": {
+                            "Ref": "RootCertificate"
+                        },
+                        "SslSupportMethod": "sni-only"
+                    }
+                }
+            },
+            "Type": "AWS::CloudFront::Distribution"
+        }
+    }
+}

--- a/source/support/topics/enclave/how-do-i-setup-an-apex-redirect-using-aws.md
+++ b/source/support/topics/enclave/how-do-i-setup-an-apex-redirect-using-aws.md
@@ -1,0 +1,144 @@
+This tutorial will guide you through the process of setting up an Apex redirect
+using AWS S3, AWS CloudFront, and AWS Certificate Manager.
+
+The heavy lifting is automated using CloudFormation, so this entire process
+shouldn't require more than a few minutes of active work.
+
+Before starting, you will need the following:
+
+- The domain you want to redirect away from (e.g.: `example.com`, `myapp.io`,
+  etc.).
+- The subdomain you want to redirect to (e.g.: `app`, `www`, etc.).
+- Access to the DNS configuration for the domain. Your DNS provider must
+  support ALIAS records (also known as CNAME flattening). We support the
+  following DNS providers in this tutorial: Amazon Route 53, CloudFlare,
+  DNSimple. If your DNS provider does not support ALIAS records, then we
+  encourage you to migrate your NS records to one that does.
+- Access to one of the mailboxes used by AWS Certificate Manager to validate
+  ownership of your domain. If you registered the domain yourself, that should
+  be the case, but otherwise [review the relevant AWS Certificate Manager
+  documentation][0] first.
+- An AWS account.
+
+After completing this tutorial, you will have an inexpensive highly-available
+redirect from your domain apex to your subdomain, which will require absolutely
+no maintenance going forward.
+
+## Create the CloudFormation Stack
+
+Navigate to [the CloudFormation Dashboard][10], and click "Create Stack".
+
+Choose "Specify an Amazon S3 template URL", and use the following template URL:
+`https://s3.amazonaws.com/www.aptible.com/assets/cloudformation-redirect.json`.
+
+Click "Next", then:
+
+- For the `Stack name`, choose any name you'll recognize in the future, e.g.:
+  `redirect-example-com`.
+- For the `Domain` parameter, input the domain you want to redirect away from.
+- For the `Subdomain` parameter, use the subdomain. Don't include the domain
+  itself there! If you want to redirect to `app.example.com`, then just input
+  `app`.
+- For the `ViewerBucketName` parameter, input any name you'll recognize in the
+  future. You cannot use dots here. A name like `redirect-example-com` will
+  work here too.
+
+Then, hit "Next", and click through the following screen as well.
+
+
+## Validate Domain Ownership
+
+In order to set up the apex redirect to require no maintenance, the
+CloudFormation template we provide uses AWS Certificate Manager to
+automatically provision and renew a (free) certificate to serve the redirect
+from your domain apex to your subdomain.
+
+To make this work, you'll need to validate with AWS that you own the domain
+you're using. So, once the CloudFormation stack enters the state
+`CREATE_IN_PROGRESS`, navigate to your mailbox, and look for an email from AWS
+to validate your domain ownership.
+
+Once you receive it, read the instructions and click through to validate.
+
+
+## Wait for a little while!
+
+Wait for the CloudFormation stack to enter the state `CREATE_COMPLETE`.
+
+This process will take about one hour, so sit back while CloudFormation does
+the work and come back once it's complete (but we'd suggest you stay around for
+the first 5 minutes or so in case an error shows up).
+
+If for some reason the process fails, review the error in the stack's Events
+tab. This may be caused by choosing a bucket name that is already in use. Once
+you've identified the error, delete the stack, and start over again.
+
+
+## Configure your DNS provider
+
+Once CloudFormation is done working, you need to tie it all together by routing
+requests from your domain apex to CloudFormation.
+
+To do this, you'll need to get the `DistributionHostname` provided by
+CloudFormation as an output for the stack. You can find it in CloudFormation
+under the Outputs tab for the stack after its state changes to
+`CREATE_COMPLETE`.
+
+Once you have the hostname in hand, the instructions depend on your DNS
+provider. See below for per-provider instructions.
+
+**If you're setting up a redirect for a domain that's already serving
+production traffic, now is a good time to check that the redirect works the way
+you expect.**
+
+To do so, use `curl` and verify that the following requests return a redirect
+to the right host (you should see a `Location` header in the response):
+
+```
+# $DOMAIN should be set to your domain apex.
+# $DISTRIBUTION should be set to the DistributionHostname.
+
+# This should redirect to your subdomain over HTTP.
+curl -v -H 'Host: $DOMAIN' 'http://$DISTRIBUTION'
+
+# This should redirect to your subdomain over HTTPS.
+curl -v -H 'Host: $DOMAIN' 'https://$DISTRIBUTION'
+```
+
+
+### Amazon Route 53
+
+Navigate to the Hosted Zone for your domain, then create a new record using the
+following options:
+
+- Name: *Leave this blank* (this represents your domain apex).
+- Type: A.
+- Alias: Yes.
+- Alias Target: the `DistributionHostname` you got from CloudFormation.
+
+
+### Cloudflare
+
+Navigate to the CloudFlare dashboard for your domain, and create a new record
+with the following options:
+
+- Type: CNAME.
+- Name: Your domain.
+- Domain Name: the `DistributionHostname` you got from CloudFormation.
+
+Cloudflare will note that CNAME flattening will be used. That's OK, and
+expected.
+
+
+### DNSimple
+
+Navigate to the DNSimple dashboard for your domain, and create a new record
+with the following options:
+
+- Type: ALIAS
+- Name: *Leave this blank* (this represents your domain apex).
+- Alias For: the `DistributionHostname` you got from CloudFormation.
+
+
+  [0]: http://docs.aws.amazon.com/acm/latest/userguide/gs-acm-validate.html
+  [10]: https://console.aws.amazon.com/cloudformation/home

--- a/source/support/topics/enclave/how-do-i-use-my-domain-apex-on-aptible.md
+++ b/source/support/topics/enclave/how-do-i-use-my-domain-apex-on-aptible.md
@@ -1,0 +1,76 @@
+Note: this article assumes that you have created [an Aptible Endpoint][0] for
+your app, and that you have the Endpoint hostname (a string that looks like
+`elb-XXX.aptible.in`) in hand. If you don't have one yet, then review that
+topic first.
+
+Aptible requires that you create a CNAME from the domain of your choice to the
+Aptible Endpoint hostname provided for your app. Unfortunately, DNS does not
+allow the creation of CNAMEs for domain apexes (also known as "bare domains" or
+"root domains").
+
+As a result, the best approach is to set up a redirection from your domain apex
+to a subdomain that points to your app on Aptible.  If you absolutely need to
+use the domain apex directly, instructions for this are provided below, but
+there are important tradeoffs to understand there.
+
+**In both cases**, you'll need a provider that supports ALIAS records (also
+known as CNAME flattening), such as Amazon Route 53, Cloudflare, or DNSimple.
+
+If your DNS records are hosted somewhere else, you will need to migrate to one
+of these providers or use a different solution (we very strongly recommend
+against doing that). Note that you only need to update the NS records for your
+domain (in other words: you can keep using your existing provider as a
+registrar, and you don't need to transfer the domain over to one of the
+providers we recommend).
+
+
+## Option 1: Set up a redirection away from your domain apex (recommended)
+
+The general idea behind setting up a redirection is to sidestep your domain
+apex entirely, and redirect your users transparently to a subdomain, from which
+you will be able to create a CNAME to the Aptible Endpoint hostname.
+
+Most customers often choose to use a subdomain such as `www` or `app` for this
+purpose.
+
+To set up a redirection from your domain apex to a subdomain, we *very*
+strongly recommend using a combination of AWS S3, AWS CloudFront, and AWS
+Certificate Manager. Using these three services, you can set up a redirection
+that requires absolutely no maintenance going forward *and* is easy to set up.
+
+To make things easier for you, Aptible provides detailed instructions to set
+this up, including an CloudFormation template that will automate all the heavy
+lifting for you. To do so, review the instructions here: [How do I set up an
+apex redirect using Amazon AWS][10]
+
+
+## Option 2: Set up an ALIAS record directly to your Aptible Endpoint
+
+Setting up an ALIAS record lets you serve your Aptible app from your domain
+apex directly (as opposed to redirecting to another domain), but there are
+significant tradeoffs here:
+
+First, this will break some Aptible functionality. Aptible configures your
+domains so that if your app goes down entirely, a backup server is used to
+serve a maintenance page ([which you can customize][5]). If you set up an ALIAS
+record directly to the Aptible Endpoint, then that functionality won't work.
+The extent of it not-working will depend on your provider:
+
+- Amazon Route 53: no error page will be served. Customers will most likely be
+  presented with an error page from their browser indicating that the site is
+  not working.
+- Cloudflare, DNSimple: a generic Aptible error page will be served.
+
+Second, depending on the provider, the ALIAS record may break in the future if
+Aptible needs to replace the underlying load balancer for your Endpoint.
+Specifically, this will be the case if your DNS provider is Amazon Route 53.
+We'll do our best to notify you if such a replacement needs to happen, but we
+cannot guarantee that you won't experience disruption during said replacement.
+
+If given these tradeoffs you still want to set up an ALIAS record directly to
+your Aptible Endpoint, please contact Aptible support for instructions.
+
+
+  [0]: /support/topics/enclave/how-to-add-internal-or-external-endpoint
+  [5]: /support/topics/enclave/how-does-the-maintenance-page-url-config-setting-work/
+  [10]: /support/topics/enclave/how-do-i-setup-an-apex-redirect-using-aws

--- a/source/support/topics/enclave/how-to-add-internal-or-external-endpoint.md
+++ b/source/support/topics/enclave/how-to-add-internal-or-external-endpoint.md
@@ -3,8 +3,12 @@ To add a custom SSL/TLS endpoint to your Aptible app, you'll first need to locat
 Once you have located the private key and certificate, select your app in the [Aptible Dashboard](https://dashboard.aptible.com), select "Endpoints," "Add Endpoint," then either select "Add New Certificate" (and paste in your certificate and private key) or reuse a previously loaded certificate. The hostname will be automatically generated based on your certificate. 
 when you select "Save Endpoint," the Aptible platform will provision the endpoint and return an endpoint address.
 
-If you want to point to a subdomain of your app (e.g. "https://www.example.com/"), use the endpoint address to configure a new CNAME record with your DNS provider.
-
-If you want to point to a "bare" or "apex" domain (e.g. "https://example.com/"), your approach will depend on which DNS provider you use. Some DNS providers provide "ALIAS" records, which allow you to point a bare domain at a hostname. Others only allow A records, which must be set to an IP address.
+If you want to point to a subdomain of your app (e.g. `https://www.example.com/`), use the endpoint address to configure a new CNAME record with your DNS provider.
 
 If you have questions about setting up this CNAME record with your DNS provider, please [contact support](http://contact.aptible.com).
+
+If you want to point to a "bare" or "apex" domain (e.g.
+`https://example.com/`), then review this support topic: [How do I use my
+domain apex on Aptible?][0]
+
+  [0]: /support/topics/enclave/how-do-i-use-my-domain-apex-on-aptible


### PR DESCRIPTION
This adds two articles explaining how to use domain apexes with Aptible:

- One that explains the two options we have (redirect to a subdomain, or
  use the apex directly).
- One that explains how to set up a redirect from the domain apex to a
  subdomain using AWS (Route 53 + CloudFormation + ACM). There's also a
  CloudFormation template here to automate that set up.

---

cc @chasballew for copy
cc @fancyremarker for the template / general technical aspects of this