### PR TITLE
Reference specific Ruby tags

### DIFF
--- a/source/support/quickstart/ruby/rails.md
+++ b/source/support/quickstart/ruby/rails.md
@@ -43,7 +43,7 @@ Here is a sample Dockerfile for a conventional Rails app:
 
   ```ruby
   # Dockerfile
-  FROM quay.io/aptible/ruby:2.3
+  FROM quay.io/aptible/ruby:2.3-ubuntu-16.04
 
   RUN apt-get update && apt-get -y install build-essential
 

--- a/source/support/topics/enclave/how-to-set-up-bundler-caching.md
+++ b/source/support/topics/enclave/how-to-set-up-bundler-caching.md
@@ -1,7 +1,7 @@
 In order for the Docker build cache to cache gems installed via Bundler, it's necessary to add the Gemfile and Gemfile.lock files to the image, and run `bundle install`, _before_ adding the rest of the repo (via `ADD .`). Here's an example of how that might look in a Dockerfile:
 
 ```
-FROM quay.io/aptible/ruby:2.3
+FROM quay.io/aptible/ruby:2.3-ubuntu-16.04
 
 # ...
 


### PR DESCRIPTION
Let's try to make sure upgrades like
https://github.com/aptible/docker-ruby/pull/18 aren't as painful in
the future.

cc @fancyremarker 