### PR TITLE
Removal of Turbolinks and minor CSS adjustments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,12 +28,8 @@ gem 'bitters'
 gem 'bourbon'
 gem 'neat'
 
-# Turbotastic!
-gem 'turbolinks', require: false
-
 # From support
 gem 'aptible-tasks', '~> 0.5.7'
-# gem 'bootstrap-sass'
 gem 'capybara'
 gem 'pry'
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,9 +322,6 @@ GEM
     timers (4.0.4)
       hitimes
     trollop (2.1.2)
-    turbolinks (5.0.1)
-      turbolinks-source (~> 5)
-    turbolinks-source (5.0.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uber (0.0.15)
@@ -354,9 +351,8 @@ DEPENDENCIES
   rake
   redcarpet
   rspec
-  turbolinks
   tzinfo-data
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   1.13.0
+   1.13.6

--- a/source/javascripts/all.js
+++ b/source/javascripts/all.js
@@ -1,3 +1,2 @@
 //= require jquery
 //= require_tree .
-//= require turbolinks

--- a/source/javascripts/carousel.coffee
+++ b/source/javascripts/carousel.coffee
@@ -1,4 +1,4 @@
-$(document).on 'turbolinks:load', ->
+$ ->
   $('.feature-carousel__btn').on 'click', ->
     $this = $(@);
     item = $this.attr('href').replace('#', '.feature-carousel--');

--- a/source/javascripts/nav.coffee
+++ b/source/javascripts/nav.coffee
@@ -1,6 +1,8 @@
-$(document).on 'turbolinks:load', ->
+$ ->
   $('.nav-toggle').on 'click', ->
-    $parent = $ $(@).parent();
+    $parent = $ $(@).parent()
     if $parent.attr('data-state') is 'open'
-      return $parent.attr 'data-state', ''
+      $parent.attr 'data-state', ''
+      return false
     $parent.attr 'data-state', 'open'
+    false

--- a/source/javascripts/openings.coffee
+++ b/source/javascripts/openings.coffee
@@ -28,7 +28,7 @@ addJobs = (job_data) ->
 
   $('.openings').html posting_html.join('')
 
-$(document).on 'turbolinks:load', ->
+$ ->
   if $('.openings').length > 0
     $.ajax
       dataType: 'json'

--- a/source/javascripts/search.coffee
+++ b/source/javascripts/search.coffee
@@ -1,4 +1,4 @@
-$(document).on 'turbolinks:load', ->
+$ ->
   button = document.getElementById('header-search-button')
   container = document.getElementById('header-search-bar')
   input = document.getElementById('swifttype-search-input')

--- a/source/javascripts/search_input.coffee
+++ b/source/javascripts/search_input.coffee
@@ -1,4 +1,4 @@
-$(document).on 'turbolinks:load', ->
+$ ->
   $form = $('#search-form')
   $field = $form.find('input') if $form.length > 0
   return unless $field

--- a/source/javascripts/search_page.coffee
+++ b/source/javascripts/search_page.coffee
@@ -1,4 +1,4 @@
-$(document).on 'turbolinks:load', ->
+$ ->
   $navSearch = $('.search-nav__input')
   if $navSearch.length > 0
     $navSearch.data 'query', $navSearch.val()

--- a/source/javascripts/sticky_side_nav.coffee
+++ b/source/javascripts/sticky_side_nav.coffee
@@ -1,4 +1,4 @@
-$(document).on 'turbolinks:load', ->
+$ ->
   $sideNav = $ '.grid-aside--left .grid-aside'
   $win = $ window
   $footer = $('.resources-footer')

--- a/source/javascripts/toolbelt.coffee
+++ b/source/javascripts/toolbelt.coffee
@@ -1,4 +1,4 @@
-$(document).on 'turbolinks:load', ->
+$ ->
   buttons = $('.toolbelt-platform')
   panels = $('.download-panels .download-panel')
   download_buttons = $('.download-button')

--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -26,7 +26,7 @@
       // No google analytics locally
       if (window.location.hostname !== 'localhost') {
         !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="3.1.0";
-        analytics.load("#{segmentio_writekey}");
+          analytics.load("#{segmentio_writekey}");
         }}();
       }
 
@@ -51,8 +51,6 @@
 
     :javascript
       // Record analytics page visits
-      $(document).on('turbolinks:load', function() {
-        if (window.location.hostname !== 'localhost') {
-          analytics.page();
-        }
-      });
+      if (window.location.hostname !== 'localhost') {
+        analytics.page();
+      }

--- a/source/stylesheets/components/_header.scss
+++ b/source/stylesheets/components/_header.scss
@@ -8,14 +8,6 @@
 .aptible-header--single-grid,
 .aptible-header--double-grid {
   position: relative;
-  @media screen and (max-width: $nav-break) {
-    .nav-list--center {
-      // Absolute childrens' top: 0 is the nearest relative parent
-      // This -34px is the top padding of .aptible-header which is now position
-      // relative in order to support the absolute pinning of the header grids.
-      top: -34px;
-    }
-  }
   .grid-container {
     position: relative;
   }
@@ -68,6 +60,15 @@
     position: absolute;
     width: 100%;
     z-index: 0;
+  }
+}
+
+@media screen and (max-width: $nav-break) {
+  .aptible-header--single-grid::before,
+  .aptible-header--double-grid::before,
+  .aptible-header--double-grid::after,
+  .aptible-header--bottom-grid::after {
+    display: none;
   }
 }
 

--- a/source/stylesheets/components/_nav.scss
+++ b/source/stylesheets/components/_nav.scss
@@ -118,7 +118,7 @@
       padding: 20px;
       position: absolute;
       text-align: left;
-      width: calc(100% - 60px);
+      top: 0;
       z-index: 10;
     }
     .nav-toggle {
@@ -185,6 +185,18 @@
       transition: opacity $base-duration $base-timing $base-duration*2;
       opacity: 1;
       position: static;
+    }
+  }
+}
+
+.aptible-header--single-grid,
+.aptible-header--double-grid {
+  @media screen and (max-width: $nav-break) {
+    .nav-list--center {
+      // Absolute childrens' top: 0 is the nearest relative parent
+      // This -34px is the top padding of .aptible-header which is now position
+      // relative in order to support the absolute pinning of the header grids.
+      top: -34px;
     }
   }
 }


### PR DESCRIPTION
Closes #353, #354, #373, #374, #390 

- CSS to adjust nav trigger placement
- Remove header SVG bg image grids on smaller screens (fixes screen flicker when scrolling)
- Removing Turbolinks fixes a host of issues:
    - dup analytics page loads (big motivator to yank it)
    - missing swiftype autocomplete menu items
    - buggy nav trigger

Will discuss with @sandersonet if we want to restore Turbolinks. Reading through the docs, it could have been a lack of a `Turbolinks.start` call and/or the order that the Turbolinks js was loaded--some things to try if we decide to bring it back.