### PR TITLE
Fix to ensure the newsletter signup success message is displayed

### DIFF
--- a/source/javascripts/newsletter.coffee
+++ b/source/javascripts/newsletter.coffee
@@ -2,3 +2,5 @@ $ ->
   $('.newsletter-form').on 'submit', ->
     message = "Thank you for subscribing to our monthly security and compliance digest."
     $(document).trigger('notify', [message])
+    # Do not reload the page!
+    return false


### PR DESCRIPTION
Tested on staging to ensure that emails are still sent to autopilot if the form submit handler returns false… and it does.