### PR TITLE
Fix newsletter signup form

### DIFF
--- a/source/javascripts/newsletter.coffee
+++ b/source/javascripts/newsletter.coffee
@@ -1,7 +1,0 @@
-$ ->
-  $('.newsletter-form').on 'submit', ->
-    message = "Thank you for subscribing to our monthly security and compliance digest."
-    $(document).trigger('notify', [message])
-    $('.newsletter-form__email').val ''
-    # Do not reload the page!
-    return false

--- a/source/javascripts/notification.coffee
+++ b/source/javascripts/notification.coffee
@@ -21,3 +21,11 @@ $ ->
 
     # Close if not removed for 10 seconds
     setTimeout notificationClose, 10000
+
+  # How we handle newsletter form submissions.
+  # Check for a hidden input that labels the event
+  loc = window.location
+  if loc.search.indexOf('event=subscribed') > -1
+    message = "Thank you for subscribing to our monthly security and compliance digest."
+    $(document).trigger('notify', [message])
+    window.history?.replaceState { }, '', loc.href.replace(loc.search, '')

--- a/source/partials/_resources-aside.haml
+++ b/source/partials/_resources-aside.haml
@@ -5,7 +5,8 @@
   %p
     Sign up to get the best in security and compliance delivered monthly.
   %form.newsletter-form
-    %input#aptible-newsletter-subscription-email.newsletter-form__email{ type: 'email', placeholder: 'Email Address' }
+    %input{ type: 'hidden', name: 'event', value: 'subscribed' }
+    %input#aptible-newsletter-subscription-email.newsletter-form__email{ name: 'newsletter-form__email', type: 'email', placeholder: 'Email Address' }
     %button.newsletter-form__submit{ type: 'submit', value: ' ' }
 
 - blog_posts_newest_first.take(3).each_with_index do |post, index|


### PR DESCRIPTION
Thanks @henryhund for finding this break. :’(

This allows the form to:
- submit, which gets the record in autopilot and reloads the page--standard html form behavior
- new JS sees the query string form submission and triggers the success flash message
- then JS replaces the location URL so subsequent reloads, back buttons, etc don't keep flashing the success message