### PR TITLE
Two Bug Fixes

### DIFF
--- a/source/blog/hello-world.md
+++ b/source/blog/hello-world.md
@@ -20,17 +20,17 @@ For the last few months, we have been working closely with a group of companies 
 We are also excited to announce our relationships with three fantastic organizations:
 <br />
 <br />
-<div align="center">[<img src="{{ blog_asset_path 'logos/ycombinator.png' }}" height="150px" />](http://www.ycombinator.com)</div>
+<div align="center">[<img src="/images/blog/logos/ycombinator.png" height="150px" />](http://www.ycombinator.com)</div>
 <br />
 Aptible is proud to be part of Y Combinator's S14 batch. All of the partners have been amazing - YC is one of those rare organizations that is every bit as great on the inside as you hope it would be from the outside. Thanks especially to Justin, Garry, Kat, Jon, and Aaron for helping us prepare for this launch.
 <br />
 <br />
 <br />
-<div align="center">[<img src="{{ blog_asset_path 'logos/rock_health.svg' }}" height="150px" />](http://rockhealth.com/)</div>
+<div align="center">[<img src="/images/blog/logos/rock_health.svg" height="150px" />](http://rockhealth.com/)</div>
 We are also part of the seventh Rock Health class. Rock Health is the premier advocate for digital health. Their entire team has been wonderful and made it a joy to come to the office every day. We are particularly grateful to Mollie, Halle, and Malay for their help so far.
 <br />
 <br />
-<div align="center">[<img src="{{ blog_asset_path 'logos/cooper.svg' }}" height="150px" />](http://www.cooper.com/)</div>
+<div align="center">[<img src="/images/blog/logos/cooper.svg" height="150px" />](http://www.cooper.com/)</div>
 Cooper is the top user experience design firm in the country. Through a partnership with Rock Health, they are helping us turn some incredibly complex regulatory and technical applications into beautiful, usable, intuitive tools that delight our customers. Lauren Ruiz and Doug LeMoine have been especially generous with their time, and we thank them!
 <br />
 <br />

--- a/source/partials/_resources-footer.haml
+++ b/source/partials/_resources-footer.haml
@@ -7,10 +7,10 @@
         Free research and guidance to help software engineering teams navigate security and compliance.
 
   .grid-container
-    .grid--3up
+    .grid--3up-flex
       - resources_by_title(titles).each do |resource|
         %a.grid-item.card.card--on-dark{ href: resource.url }
           .card__header
             .card__subtitle.card__subitle--on-dark= resource_subtitle(resource)
             %h3.card__title.card__title--on-dark= resource.data.title
-          .card__body.card__body--on-dark= resource.data.excerpt
+          %p.card__body.card__body--on-dark= resource.data.excerpt

--- a/source/stylesheets/_cards.scss
+++ b/source/stylesheets/_cards.scss
@@ -54,7 +54,6 @@
 }
 .card__body--on-dark {
   color: tint($light-sky-blue, 75%);
-  height: 50px;
 }
 
 .card--on-dark {

--- a/source/stylesheets/_grid.scss
+++ b/source/stylesheets/_grid.scss
@@ -115,6 +115,21 @@ body {
   }
 }
 
+.grid--3up-flex {
+  align-items: stretch;
+  display: flex;
+  justify-content: space-between;
+  .grid-item {
+    width: 32%;
+  }
+  @media screen and (max-width: $tablet-portrait) {
+    flex-direction: column;
+    .grid-item {
+      width: 100%;
+    }
+  }
+}
+
 .grid-item--two-thirds {
   @include span-columns(8);
   @media screen and (max-width: $tablet-landscape) {


### PR DESCRIPTION
The Hello World blog post had broken image references.

Fixes this issue with varying content length in the resource footer cards
Busted:
<img width="1436" alt="screen shot 2017-02-10 at 2 51 41 pm" src="https://cloud.githubusercontent.com/assets/94830/22847241/875c7d9e-efa0-11e6-8c45-d24f45fecc3f.png">
Fixed:
<img width="1429" alt="screen shot 2017-02-10 at 2 52 39 pm" src="https://cloud.githubusercontent.com/assets/94830/22847244/986b501a-efa0-11e6-96ce-8fb3e2b098f2.png">

