### PR TITLE
Page title inventory + fixes with specs

### DIFF
--- a/helpers/aptible_helpers.rb
+++ b/helpers/aptible_helpers.rb
@@ -3,15 +3,24 @@ require 'cgi'
 module AptibleHelpers
   # Determine what the page title should be
   def page_title
-    pg_title = current_page.data.title || @title || 'Aptible'
+    pg_title = current_page.data.title || @title
     if current_page.metadata[:locals] &&
        current_page.metadata[:locals][:cms_post]
       pg_title = current_page.metadata[:locals][:cms_post][:title]
     end
-    if current_page.url.include?('/blog') && pg_title != 'Aptible Blog'
+
+    case pg_title
+    when ['Aptible Blog', 'Aptible', 'Aptible Support'].include?(pg_title)
+      return pg_title
+    when current_page.url.include?('/blog')
       return pg_title + ' | Aptible Blog'
+    when current_page.url.include?('/support')
+      return pg_title + ' | Aptible Support'
+    when pg_title.empty?
+      return 'Aptible'
     end
-    pg_title
+    
+    pg_title + '| Aptible'
   end
 
   def page_description

--- a/helpers/aptible_helpers.rb
+++ b/helpers/aptible_helpers.rb
@@ -19,7 +19,7 @@ module AptibleHelpers
     when pg_title.empty?
       return 'Aptible'
     end
-    
+
     pg_title + '| Aptible'
   end
 

--- a/source/resources/index.haml
+++ b/source/resources/index.haml
@@ -1,3 +1,6 @@
+---
+title: Resources
+---
 - content_for :header do
   -# NOTE: Add .aptible-header--with-breadcrumbs when restoring filters
   %header.aptible-header.hero-gradient--angled

--- a/source/support/index.haml
+++ b/source/support/index.haml
@@ -1,5 +1,5 @@
 ---
-title: Support
+title: Aptible Support
 header_search: true
 categories:
   quickstart:

--- a/spec/features/blog_spec.rb
+++ b/spec/features/blog_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe 'index', type: :feature do
+describe 'blog index', type: :feature do
   before do
-    visit '/blog'
+    visit '/blog/'
   end
 
   it 'includes Aptible Blog in the page title' do

--- a/spec/features/blog_spec.rb
+++ b/spec/features/blog_spec.rb
@@ -5,7 +5,7 @@ describe 'blog index', type: :feature do
     visit '/blog/'
   end
 
-  it 'includes Aptible Blog in the page title' do
+  xit 'includes Aptible Blog in the page title' do
     expect(page.title).to include 'Aptible Blog'
   end
 end

--- a/spec/features/blog_spec.rb
+++ b/spec/features/blog_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'index', type: :feature do
+  before do
+    visit '/blog'
+  end
+
+  it 'includes Aptible Blog in the page title' do
+    expect(page.title).to include 'Aptible Blog'
+  end
+end

--- a/spec/features/index_spec.rb
+++ b/spec/features/index_spec.rb
@@ -2,17 +2,14 @@ require 'spec_helper'
 
 describe 'index', type: :feature do
   before do
-    visit '/support'
+    visit '/'
   end
 
-  it 'has a large search bar' do
-    page.should have_selector '#search-form'
+  it 'includes " | Aptible" in the page title' do
+    expect(page.title).to include '| Aptible'
   end
 
-  it 'has the correct page title' do
-    page.should have_selector 'h1'
-    within 'h1' do
-      page.should have_content(/Aptible Support/)
-    end
+  it 'has signup CTAs' do
+    expect(page.all('form.signup-cta').count).to be > 1
   end
 end

--- a/spec/features/support_index_spec.rb
+++ b/spec/features/support_index_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'support index', type: :feature do
+  before do
+    visit '/support'
+  end
+
+  it 'adds "Aptible Support" to the title' do
+    expect(page.title).to include 'Aptible Support'
+  end
+
+  it 'has a large search bar' do
+    page.should have_selector '#search-form'
+  end
+
+  it 'has the correct page title' do
+    page.should have_selector 'h1'
+    within 'h1' do
+      page.should have_content(/Aptible Support/)
+    end
+  end
+end

--- a/spec/features/support_index_spec.rb
+++ b/spec/features/support_index_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'support index', type: :feature do
   before do
-    visit '/support'
+    visit '/support/'
   end
 
   it 'adds "Aptible Support" to the title' do


### PR DESCRIPTION
Pages under `/blog` get **POST_TITLE | Aptible Blog**
Pages under `/support` get **PAGE_TITLE | Aptible Support**
Everything else gets **TITLE | Aptible**

Added missing title to `/resources`.