### PR TITLE
Messed up support breadcrumbs with header change

### DIFF
--- a/source/partials/headers/_support-document.haml
+++ b/source/partials/headers/_support-document.haml
@@ -1,4 +1,4 @@
-%header.aptible-header.hero-gradient--angled.aptible-header--single-grid
+%header.aptible-header.hero-gradient--angled.aptible-header--single-grid.aptible-header--with-breadcrumbs
   = partial 'partials/main-nav', locals: {      |
       nav_items: 'partials/support/nav-items',  |
       section_title: 'Support',                 |

--- a/source/support/topics/category.haml
+++ b/source/support/topics/category.haml
@@ -1,5 +1,5 @@
 - content_for :header do
-  %header.aptible-header.hero-gradient--angled.aptible-header--single-grid
+  %header.aptible-header.hero-gradient--angled.aptible-header--single-grid.aptible-header--with-breadcrumbs
     = partial 'partials/main-nav', locals: {      |
         nav_items: 'partials/support/nav-items',  |
         section_title: 'Support',                 |


### PR DESCRIPTION
This removes the header bottom margin to get cozy with the bread crumbs from:
![screen shot 2017-03-08 at 5 42 46 pm](https://cloud.githubusercontent.com/assets/94830/23732240/c9a74cca-0426-11e7-944e-34fcd894cfdf.png)

Back to:
![screen shot 2017-03-08 at 5 43 34 pm](https://cloud.githubusercontent.com/assets/94830/23732249/d2072b2e-0426-11e7-9777-357cefae5bb5.png)
