### PR TITLE
Restored page title and description from contentful data

### DIFF
--- a/source/resources/resource.haml
+++ b/source/resources/resource.haml
@@ -1,6 +1,8 @@
 ---
 layout: resource.haml
 ---
+- @title = resource.title
+- @description = resource.metaDescription || resource.snippet
 - if resource.webinarVideoLink
   %p.text-center
     %iframe{ width: '560', height: '315', src: resource.webinarVideoLink, frameborder: '0', allowfullscreen: 'allowfullscreen' }


### PR DESCRIPTION
If a resource has no `metaDescription` defined, `snippet` will be used.