### PR TITLE
Update the support topic for environment variables.

### DIFF
--- a/source/support/topics/cli/how-to-set-environment-variables.md
+++ b/source/support/topics/cli/how-to-set-environment-variables.md
@@ -14,3 +14,6 @@ To set multiple variables, use the syntax:
 aptible config:set --app $APP_HANDLE VAR1=value1 VAR2=value2 ...
 ```
 
+To properly escape the value of an ENV variable that contains special characters such as spaces or newlines, you can read the variable directly from a file:
+
+    aptible config --app $APP_HANDLE CONFIG_FILE="$(cat appconfig.json)" CERTIFICATE="$(cat mysite.pem)"


### PR DESCRIPTION
This adds an example for a common use case: properly escaping values that contain special characters.