### PR TITLE
Minor CSS fixes

### DIFF
--- a/source/stylesheets/base/_lists.scss
+++ b/source/stylesheets/base/_lists.scss
@@ -18,6 +18,15 @@ ul {
   }
 }
 
+li > ul {
+  margin-top: 1em;
+  margin-bottom: 0;
+}
+
+li > p:last-of-type {
+  margin-bottom: 0;
+}
+
 ul.checklist {
   list-style-image: image-url('icons/checklist-item.svg');
   margin-left: 20px;

--- a/source/stylesheets/components/_search-bar.scss
+++ b/source/stylesheets/components/_search-bar.scss
@@ -95,7 +95,7 @@
   svg {
     cursor: pointer;
     display: inline-block;
-    display: none;
+    opacity: 0;
     position: relative;
     transform: translate(-17px, 3px);
     z-index: 0;
@@ -137,6 +137,7 @@
     box-shadow: none;
     & + svg {
       display: inline-block;
+      opacity: 1;
       path {
         fill: $blue-steel;
       }
@@ -145,7 +146,7 @@
 }
 
 .search-nav__input--with-transition {
-  transition: width $base-duration * 2 $base-timing;
+  transition: width ($base-duration * .8) $base-timing;
 }
 
 //


### PR DESCRIPTION
- adjust animation speed and placement of expanding support search header input
- remove bottom padding from the last `<p>` tag in an `<li>`

The longer term fix for the `<li><p>Hello</p></li>` situation is to adjust the configuration of the markdown renderer. Looking into it.