### PR TITLE
Update README to mention middleman contentful

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Install necessary dependencies:
 
     bundle install
 
+Load some blog posts, the site won't work otherwise:
+
+    bundle exec middleman contentful
+
 Start the server. You can access it at http://localhost:4567/
 
     bundle exec middleman server


### PR DESCRIPTION
`data.aptible` is accessed in an number of places in helpers, but that
won't work if you haven't run `middleman contentful` first.

Ideally, we probably should either handle the absence of contentful data
gracefully or crash with an explicit error, but I don't really have the
familiarity with middleman / contentful to know how that might be done.

---

cc @gib 