### PR TITLE
Don't use relative links in documentation

### DIFF
--- a/source/support/topics/enclave/about-aptible-yml.md
+++ b/source/support/topics/enclave/about-aptible-yml.md
@@ -23,4 +23,4 @@ restart`, etc.
 For usage examples, see [How do I automate database migrations for my
 app?][database-migrations].
 
-  [database-migrations]: ./how-to-automate-database-migrations
+  [database-migrations]: /support/topics/enclave/how-to-automate-database-migrations/

--- a/source/support/topics/enclave/direct-docker-image-deploy.md
+++ b/source/support/topics/enclave/direct-docker-image-deploy.md
@@ -170,8 +170,8 @@ updated files to. In the `git push` example above, that's
 `update-the-Procfile`.
 
 
-  [aptible-toolbelt]: ../../toolbelt
-  [dockerfile-build-deploy]: ./dockerfile-build-deploy
-  [about-services]: ./about-services
-  [about-aptible-yml]: ./about-aptible-yml
-  [private-registry-authentication]: ./private-registry-authentication
+  [aptible-toolbelt]: /support/toolbelt/
+  [dockerfile-build-deploy]: /support/topics/enclave/dockerfile-build-deploy/
+  [about-services]: /support/topics/enclave/about-services/
+  [about-aptible-yml]: /support/topics/enclave/about-aptible-yml/
+  [private-registry-authentication]: /support/topics/enclave/private-registry-authentication/

--- a/source/support/topics/enclave/dockerfile-build-deploy.md
+++ b/source/support/topics/enclave/dockerfile-build-deploy.md
@@ -108,7 +108,7 @@ aptible deploy --app "$APP_HANDLE" --docker-image ""
 ```
 
   [docker-get-started]: https://docs.docker.com/get-started/
-  [quickstart-guides]: ../../quickstart
+  [quickstart-guides]: /support/quickstart/
   [aptible-support]: http://contact.aptible.com
-  [direct-docker-image-deploy]: ./direct-docker-image-deploy
-  [private-registry-authentication]: ./private-registry-authentication
+  [direct-docker-image-deploy]: /support/topics/enclave/direct-docker-image-deploy/
+  [private-registry-authentication]: /support/topics/enclave/private-registry-authentication/

--- a/source/support/topics/enclave/how-to-add-background-worker.md
+++ b/source/support/topics/enclave/how-to-add-background-worker.md
@@ -6,4 +6,4 @@ following line:
 
     worker: bundle exec sidekiq
 
-  [about-services]: ./about-services
+  [about-services]: /support/topics/enclave/about-services/

--- a/source/support/topics/enclave/how-to-auto-restart-your-app.md
+++ b/source/support/topics/enclave/how-to-auto-restart-your-app.md
@@ -43,4 +43,4 @@ automatically restart an app after it crashes.
   web: forever app.js
   ```
 
-  [about-services]: ./about-services
+  [about-services]: /support/topics/enclave/about-services/

--- a/source/support/topics/enclave/how-to-deploy-app.md
+++ b/source/support/topics/enclave/how-to-deploy-app.md
@@ -44,6 +44,6 @@ Enclave instead.
 
 For more detail, see [About Services][about-services].
 
-  [dockerfile-build-deploy]: ./dockerfile-build-deploy
-  [direct-docker-image-deploy]: ./direct-docker-image-deploy
-  [about-services]: ./about-services
+  [dockerfile-build-deploy]: /support/topics/enclave/dockerfile-build-deploy/
+  [direct-docker-image-deploy]: /support/topics/enclave/direct-docker-image-deploy/
+  [about-services]: /support/topics/enclave/about-services/

--- a/source/support/topics/enclave/how-to-run-scheduled-tasks.md
+++ b/source/support/topics/enclave/how-to-run-scheduled-tasks.md
@@ -22,6 +22,6 @@ about the Procfiles, see [About Services][about-services].
 Another option for running scheduled tasks on Aptible is to use the Whenever
 gem. More on that approach [over here][whenever]
 
-  [about-services]: ./about-services
+  [about-services]: /support/topics/enclave/about-services/
   [docker-cron-example]: https://github.com/aptible/docker-cron-example
-  [whenever]: ./how-to-use-whenever
+  [whenever]: /support/topics/enclave/how-to-use-whenever/

--- a/source/support/topics/enclave/how-to-scale-app.md
+++ b/source/support/topics/enclave/how-to-scale-app.md
@@ -9,4 +9,4 @@ adjust the "Memory" slider. When you are ready, select "Scale." The Aptible
 platform will scale your app service to your new specifications. You can use
 the same process to scale your app down.
 
-  [about-services]: ./about-services
+  [about-services]: /support/topics/enclave/about-services/

--- a/source/support/topics/enclave/how-to-use-whenever.md
+++ b/source/support/topics/enclave/how-to-use-whenever.md
@@ -56,4 +56,4 @@ then your image is missing `cron.` To install `cron`, you'll need to add `cron`
 as an apt dependency in your`Dockerfile`: `RUN apt-get update && apt-get -y
 install cron`.
 
-  [about-services]: ./about-services
+  [about-services]: /support/topics/enclave/about-services/

--- a/source/support/topics/enclave/private-registry-authentication.md
+++ b/source/support/topics/enclave/private-registry-authentication.md
@@ -104,5 +104,5 @@ aptible deploy \
 ```
 
 
-  [dockerfile-build-deploy]: ./dockerfile-build-deploy
-  [direct-docker-image-deploy]: ./direct-docker-image-deploy
+  [dockerfile-build-deploy]: /support/topics/enclave/dockerfile-build-deploy/
+  [direct-docker-image-deploy]: /support/topics/enclave/direct-docker-image-deploy/

--- a/source/support/topics/enclave/zero-downtime-deploys.md
+++ b/source/support/topics/enclave/zero-downtime-deploys.md
@@ -27,4 +27,4 @@ using the following sequence of operations:
 - Launch the new containers.
 
 
-  [about-services]: ./about-services
+  [about-services]: /support/topics/enclave/about-services/


### PR DESCRIPTION
As it happens, relative links (which work locally) don't work in
production, which is a bit of a footgun. This updates relative links to
unbreak things for now.