### PR TITLE
Update Pilot Account Pricing

### DIFF
--- a/source/pricing.haml
+++ b/source/pricing.haml
@@ -24,7 +24,7 @@ description: "Aptible plans and pricing"
         .pricing-tier__title Development
       %ul.pricing-tier__checklist.checklist.checklist--blue
         %li.pricing-tier__checklist-item Aptible Enclave deployment platform
-        %li.pricing-tier__checklist-item No contracts, no commitments
+        %li.pricing-tier__checklist-item No contracts, no commitment
         %li.pricing-tier__checklist-item $500 credit towards usage for new accounts
         %li.pricing-tier__checklist-item Shared tenancy
         %li.pricing-tier__checklist-item Ideal for development or staging


### PR DESCRIPTION
Update Pilot Account Pricing from $1,999/mo to $3,499/mo - so when we speak to customers about pricing, we're able to provide them with a discount.

Note: The pricing update in this commit https://github.com/aptible/www.aptible.com/commit/df6f93a5115fe2f4fe668c6ee3f3cedaff2f8c32 went straight to master, but was meant for this PR.