### PR TITLE
Changes to support preview.aptible.com

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM ruby:2.3
+
+# Install Supercronic
+ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.2/supercronic-linux-amd64 \
+    SUPERCRONIC=supercronic-linux-amd64 \
+    SUPERCRONIC_SHA1SUM=cdfde14f50a171cbfc35a3a10429e2ab0709afe0
+
+RUN curl -fsSLO "$SUPERCRONIC_URL" \
+ && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
+ && chmod +x "$SUPERCRONIC" \
+ && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
+ && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic
+
+# Install Node.js (required as execjs runtime)
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends nodejs && \
+  rm -rf /var/lib/apt/lists/*
+
+ADD Gemfile /opt/www.aptible.com/
+ADD Gemfile.lock /opt/www.aptible.com/
+WORKDIR /opt/www.aptible.com
+RUN bundle install
+
+ADD . /opt/www.aptible.com
+
+EXPOSE 4567
+
+CMD ["script/aptible-cmd.sh"]
+
+

--- a/helpers/contentful_helpers.rb
+++ b/helpers/contentful_helpers.rb
@@ -1,5 +1,8 @@
 require 'contentful'
 
+Encoding.default_external = Encoding::UTF_8
+Encoding.default_internal = Encoding::UTF_8
+
 module ContentfulHelpers
   MARKDOWN_PROCESSORS = {
     'blogPost' => lambda do |yml|

--- a/helpers/contentful_helpers.rb
+++ b/helpers/contentful_helpers.rb
@@ -62,18 +62,45 @@ module ContentfulHelpers
   }.freeze
 
   def self.populate!
+    filelist = []
     Dir.mktmpdir do |dir|
       fetch_yaml_files!(dir)
       MARKDOWN_PROCESSORS.keys.each do |type|
         Dir.glob(File.join(dir, "#{type}/*.yml")).each do |yaml_file|
           yaml = File.read(yaml_file)
-          markdown_map(type, yaml).each do |path, markdown|
-            dest = File.join(File.dirname(__FILE__), '..', path)
+
+          begin
+            map = markdown_map(type, yaml)
+          rescue => e
+            puts "WARN: Failed to parse #{File.basename(yaml_file)}"
+            puts "WARN:   #{e.message}"
+            next
+          end
+
+          map.each do |path, markdown|
+            dest = File.expand_path("../#{path}", File.dirname(__FILE__))
+            filelist << dest
+            next if File.exist?(dest) && markdown == File.read(dest)
+            puts "INFO: Updating #{dest}"
             File.open(dest, 'w') { |file| file << markdown }
           end
         end
       end
     end
+
+    # If ENV['CONTENTFUL_PRUNE_ON_POPULATE'] is set, prune local Markdown
+    # files previously pulled from Contentful with no matching resource
+    return unless prune_on_populate?
+    (local_contentful_filenames - filelist).each do |dest|
+      puts "INFO: Pruning #{dest}"
+      FileUtils.rm(dest)
+    end
+  end
+
+  def self.local_contentful_filenames
+    pattern = '../source/**/*.md'
+    all = Dir.glob(File.expand_path(pattern, File.dirname(__FILE__)))
+    all.select { |f| File.read(f).lines.grep(/^contentful: true$/).any? }
   end
 
   def self.fetch_yaml_files!(tempdir)
@@ -110,10 +137,10 @@ module ContentfulHelpers
   def self.markdown_map(type, yaml_string)
     Hash[MARKDOWN_PROCESSORS[type].call(YAML.load(yaml_string)).map do |hash|
       markdown = ''
-      if hash[:frontmatter]
-        markdown << hash[:frontmatter].to_yaml.gsub(/ *$/, '')
-        markdown << "---\n\n"
-      end
+      frontmatter = { 'contentful' => true }
+      frontmatter.merge!(hash[:frontmatter] || {})
+      markdown << frontmatter.to_yaml.gsub(/ *$/, '')
+      markdown << "---\n\n"
       markdown << hash[:markdown]
 
       [hash[:markdown_path], markdown]
@@ -135,6 +162,10 @@ module ContentfulHelpers
 
   def self.space_id
     ENV['CONTENTFUL_SPACE_ID'] || '8djp5jlzqrnc'
+  end
+
+  def self.prune_on_populate?
+    !!ENV['CONTENTFUL_PRUNE_ON_POPULATE']
   end
 
   def self.client

--- a/script/aptible-cmd.sh
+++ b/script/aptible-cmd.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+# Start cron (to pull in Contentful content)
+supercronic /opt/www.aptible.com/script/contentful.crontab &
+
+# Start Middleman server
+bundle exec middleman server --reload-paths source/

--- a/script/contentful.crontab
+++ b/script/contentful.crontab
@@ -1,0 +1,1 @@
+* * * * *  cd /opt/www.aptible.com && bundle exec rake contentful:pull

--- a/spec/fixtures/contentful/blog/introducing-direct-docker-image-deploy/output.md
+++ b/spec/fixtures/contentful/blog/introducing-direct-docker-image-deploy/output.md
@@ -1,4 +1,5 @@
 ---
+contentful: true
 title: Introducing Direct Docker Image Deploy
 excerpt: You can now deploy apps on Enclave directly from a Docker image in addition
   to Enclave’s traditional git-based deployment process.

--- a/spec/fixtures/contentful/blog/vulnerability-scanning-for-your-dependencies-why-and-how/output.md
+++ b/spec/fixtures/contentful/blog/vulnerability-scanning-for-your-dependencies-why-and-how/output.md
@@ -1,4 +1,5 @@
 ---
+contentful: true
 title: 'Vulnerability Scanning for your Dependencies: Why and How '
 excerpt: Scanning for vulnerabilities in your dependencies is crucial to your application's
   security. Here's why (and how to do it).

--- a/spec/fixtures/contentful/changelog/managed-https-endpoints-now-support-internal-endpoints/output.md
+++ b/spec/fixtures/contentful/changelog/managed-https-endpoints-now-support-internal-endpoints/output.md
@@ -1,4 +1,5 @@
 ---
+contentful: true
 title: Managed HTTPS Endpoints now support Internal Endpoints
 excerpt: Internal-facing apps can now enjoy the benefits of Managed HTTPS Endpoints.
 author_name: Thomas Orozco

--- a/spec/fixtures/contentful/learn/hipaa-compliance-for-developers-getting-started/output.md
+++ b/spec/fixtures/contentful/learn/hipaa-compliance-for-developers-getting-started/output.md
@@ -1,4 +1,5 @@
 ---
+contentful: true
 category: HIPAA Compliance
 cover_image:
   :title: 'Resource: HIPAA Compliance for Developers'

--- a/spec/fixtures/contentful/resources/gridiron-reference-documents/output.md
+++ b/spec/fixtures/contentful/resources/gridiron-reference-documents/output.md
@@ -1,4 +1,5 @@
 ---
+contentful: true
 category: Aptible Product Reference
 cover_image:
 created_at: !ruby/object:DateTime 2017-01-23 00:00:00.000000000 -04:00

--- a/spec/fixtures/contentful/resources/what-is-a-hipaa-baa/output.md
+++ b/spec/fixtures/contentful/resources/what-is-a-hipaa-baa/output.md
@@ -1,4 +1,5 @@
 ---
+contentful: true
 category: HIPAA Compliance
 cover_image:
   :title: 'Resource: What is HIPAA BAA'

--- a/spec/fixtures/contentful/webinars/update-webinar-april-2017/_output-transcript.md
+++ b/spec/fixtures/contentful/webinars/update-webinar-april-2017/_output-transcript.md
@@ -1,3 +1,7 @@
+---
+contentful: true
+---
+
 **Chas Ballew:**	Okay, let's get started. Thank you everybody for joining. This is the ... Oh boy, can I go backwards? This is the April 2017 Aptible Update Webinar. This is part our quarterly webinar series. We're giving one of these every quarter, in order to give everybody updates and insight into what we've been working on over the last quarter. The agenda for today will be like most of these. [00:00:30] First our enclave team lead Thomas Orozco will go through the enclave features and updates that we've shipped over the last quarter since January. Then Skylar Anderson our grid iron lead will cover grid iron updates and availability for that. Then we'll have time for open questions at the end.
 
 As we go along, if you have questions that come up, go ahead and use the Q&A feature in zoom here, to just put those [00:01:00] in. Then Frank Macreery our CTO will moderate and make sure that all of those get answered. We're going to be recording this as we go. Afterwards we'll post the recording and a transcript and a link to register for the July update webinar on our blog, or on our resources page rather. So, aptible.com/resources. We'll also tweet a link out to that. With that, [00:01:30] I'm going to turn it over to Thomas, thank you.

--- a/spec/fixtures/contentful/webinars/update-webinar-april-2017/output.md
+++ b/spec/fixtures/contentful/webinars/update-webinar-april-2017/output.md
@@ -1,4 +1,5 @@
 ---
+contentful: true
 category: Webinars
 cover_image:
 created_at: !ruby/object:DateTime 2017-04-19 00:00:00.000000000 -07:00


### PR DESCRIPTION
Currently, we rely on Contentful Webhooks to push to Travis CI in order to be able to (a) preview Contentful changes on staging before publishing, and (b) publish Contentful changes without explicitly running a deploy. While this is [Contentful's recommended approach](https://www.contentful.com/developers/docs/ruby/tutorials/automated-rebuild-and-deploy-with-circleci-and-webhooks/), it's got a couple downsides:

1. Changes are slow to be able to preview on staging. The Travis CI build takes about 5 minutes on average, and then CloudFront caching means they may take up to an extra 5 minutes to appear on staging/production. So, it can sometimes take up to 10 minutes for a Contentful change to be visible on staging.
2. The Contentful webhook to Travis CI often fails (429 Too Many Requests), so sometimes (actually, > 30% of the time) changes don't even make it to staging/production.

My proposed solution is:

* Get rid of Contentful webhooks entirely
* Use [preview.aptible.com](https://preview.aptible.com) as a new default place for previewing Contentful changes: This is the subject of this PR, which allows us to host preview.aptible.com on Aptible Enclave, pulling in new content from Contentful once per minute on a cron. Because we're bypassing CloudFront, we also avoid the cache invalidation latency. So Contentful changes should be visible on preview.aptible.com within a minute. We can bring this latency down even further in the future, by adding a webhook listener to preview.aptible.com which can be pinged by Contentful to trigger a new pull from Contentful.
* Deploy to www.aptible.com and www.aptible-staging.com every 15 minutes, via a separate cron app. This means that published changes may take up to 20 minutes to appear on production, but I believe that's an acceptable price to pay for predictability.

This is set up on [preview.aptible.com](https://preview.aptible.com) if you'd like to test it out.

cc: @gib @henryhund 