### PR TITLE
Allow for overriding a specific Hacker News link, including via Contentful

### DIFF
--- a/helpers/contentful_helpers.rb
+++ b/helpers/contentful_helpers.rb
@@ -15,7 +15,8 @@ module ContentfulHelpers
           'posted' => Time.parse(yml[:posted]).to_date,
           'product' => yml[:product],
           'section' => 'Blog',
-          'type' => yml[:type]
+          'type' => yml[:type],
+          'hackernews_link' => yml[:hackernews_link]
         }
       }]
     end,

--- a/source/blog/y-combinator.md
+++ b/source/blog/y-combinator.md
@@ -4,7 +4,7 @@ excerpt: "Can you get into Y Combinator? Absolutely. Here's why and how."
 author_name: Chas Ballew
 author_email: chas@aptible.com
 author_id: chas
-hn_url: https://www.aptible.com/blog/y_combinator.html
+hackernews_link: https://news.ycombinator.com/item?id=8334957
 posted: 2014-09-18
 section: Blog
 type: blog post
@@ -25,10 +25,10 @@ No.
 
 There are two main reasons for this:
 
-*__The application process itself is valuable.__*  
-Preparing the application requires you to think carefully about your idea, your company, your market, your team, and the obstacles in your way. Forcing yourself to reflect honestly is painful, but extremely beneficial. Seize the opportunity to do it now.  
+*__The application process itself is valuable.__*
+Preparing the application requires you to think carefully about your idea, your company, your market, your team, and the obstacles in your way. Forcing yourself to reflect honestly is painful, but extremely beneficial. Seize the opportunity to do it now.
 
-*__You have a better chance than you think.__*  
+*__You have a better chance than you think.__*
 The traits YC looks for in companies and founders are well-known and addressable. By "well-known," I mean go read PG and Sam's essays. By "addressable," I mean you can improve your chances with focused work and practice. If your company doesn't have the ideal characteristics, you can acquire the important ones. If you have the right ingredients, you can learn to convey that clearly and concisely.
 
 That's why you should [apply now](http://www.ycombinator.com/apply/).
@@ -66,9 +66,9 @@ Some tips:
 
 ## Step 2: Interview
 
-The application questions are a subset of the questions you may be asked at an interview.  
+The application questions are a subset of the questions you may be asked at an interview.
 
-Before our interview, Frank and I:  
+Before our interview, Frank and I:
 
 - Collected all of the known Y Combinator interview questions we could find
 - Wrote out 1-2 sentence answers
@@ -87,7 +87,7 @@ Below are the questions we used to prepare. I don't remember where we found each
 
 *Remember:* One or two sentences each. If you prepare longer answers, you'll be flustered when the YC partners cut you off to ask another question. James Cunningham and Colin Hayhurst (GoScale, S12) built a [fun app with a timer](http://ipaulgraham.herokuapp.com/) to help you practice concise answers.
 
-### **Critical questions**  
+### **Critical questions**
 
 These are the most important questions. They are all different ways of determining if you make something people want. You need to have a good answer, or an excellent reason for not having an answer. Many of these are in the application itself.
 

--- a/source/javascripts/hn_button.js
+++ b/source/javascripts/hn_button.js
@@ -1,11 +1,14 @@
 $.fn.hnButton = function() {
   // this is the button to be upgraded
   var linkbutton = this;
+
+  // bypass Algolia if we know the Hacker News discussion URL
+  if (linkbutton.data('override')) {
+    return linkbutton;
+  }
+
   var title = document.title;
   var thisUrl = window.location.href;
-  if (linkbutton.data('url')) {
-    thisUrl = linkbutton.data('url');
-  }
   if (linkbutton.data('title')) {
     title = linkbutton.data('title');
   }
@@ -29,7 +32,6 @@ $.fn.hnButton = function() {
       if (data.nbHits > 0) {
         $.each(data.hits, function(index, item){
           if (item.url === thisUrl) {
-            debugger;
             // this is our item!
             var hnPostLink = hnUrlPrefix + item.objectID;
             linkbutton.unbind('click');

--- a/source/partials/_blog-social-share.haml
+++ b/source/partials/_blog-social-share.haml
@@ -10,13 +10,13 @@
   %a.blog-post__share-link.blog-post__share-link--linkedin{ href: linkedin_share_href(post), rel: 'noopener noreferrer', target: '_blank' }
     = partial "images/icons/social/linkedin.svg"
 
-  %a.blog-post__share-link.blog-post__share-link--hackernews{ |
-      "data-url" => post.data.hn_url ? post.data.hn_url : '', |
-      "data-title" => post.data.title,                        |
-      href: hackernews_share_href(post),                      |
-      rel: 'noopener noreferrer',                             |
-      target: '_blank'                                        |
-    }                                                         |
+  %a.blog-post__share-link.blog-post__share-link--hackernews{         |
+      "data-override" => post.data.hackernews_link,                   |
+      "data-title" => post.data.title,                                |
+      href: post.data.hackernews_link || hackernews_share_href(post), |
+      rel: 'noopener noreferrer',                                     |
+      target: '_blank'                                                |
+    }                                                                 |
     = partial "images/icons/social/hackernews.svg"
 
   %a.blog-post__share-link.blog-post__share-link--email{ href: mailto_share_href(post) }

--- a/spec/fixtures/contentful/blog/introducing-direct-docker-image-deploy/input.yml
+++ b/spec/fixtures/contentful/blog/introducing-direct-docker-image-deploy/input.yml
@@ -53,3 +53,4 @@
   :slug: thomas
   :email: thomas@aptible.com
   :gravatar: https://s.gravatar.com/avatar/f532cf09084eb963bfc913867fff2258
+:hackernews_link: https://news.ycombinator.com/item?id=13759706

--- a/spec/fixtures/contentful/blog/introducing-direct-docker-image-deploy/output.md
+++ b/spec/fixtures/contentful/blog/introducing-direct-docker-image-deploy/output.md
@@ -9,6 +9,7 @@ posted: 2017-06-13
 product: enclave
 section: Blog
 type: blog post
+hackernews_link: https://news.ycombinator.com/item?id=13759706
 ---
 
 We’re proud to announce that you can now deploy apps on Enclave directly from a Docker image, bypassing Enclave’s traditional git-based deployment process.

--- a/spec/fixtures/contentful/blog/vulnerability-scanning-for-your-dependencies-why-and-how/output.md
+++ b/spec/fixtures/contentful/blog/vulnerability-scanning-for-your-dependencies-why-and-how/output.md
@@ -9,6 +9,7 @@ posted: 2017-05-22
 product: enclave
 section: Blog
 type: blog post
+hackernews_link:
 ---
 
 In a world where application dependency graphs are deeper than ever, secure engineering means more than securing your own software: tracking vulnerabilities in your dependencies is just as important.

--- a/spec/fixtures/contentful/changelog/managed-https-endpoints-now-support-internal-endpoints/output.md
+++ b/spec/fixtures/contentful/changelog/managed-https-endpoints-now-support-internal-endpoints/output.md
@@ -8,6 +8,7 @@ posted: 2017-03-14
 product: enclave
 section: Blog
 type: changelog post
+hackernews_link:
 ---
 
 We’re happy to announce that [Managed HTTPS](https://www.aptible.com/blog/managed-https/) is now available on Enclave for Internal Endpoints (in addition to External Endpoints, which were supported from day 1).


### PR DESCRIPTION
@gib: This alters the existing override behavior a bit. Instead of providing an alternate link with which to search Algolia, I thought it would be easier, and more direct/generic to provide the desired Hacker News discussion to link to. LMK if this won't work!