### PR TITLE
FormKeep Forms

### DIFF
--- a/source/partials/_newsletter-signup--blog.haml
+++ b/source/partials/_newsletter-signup--blog.haml
@@ -4,7 +4,9 @@
     %br
     Subscribe to get the best in security, compliance and DevOps delivered monthly.
 
-  %form.newsletter-signup--blog__form.signup-cta--small
+  %form.newsletter-signup--blog__form.signup-cta--small{ action: 'https://formkeep.com/f/6d5e9ddb6e0e', method: 'post' }
     %input{ type: 'hidden', name: 'event', value: 'subscribed' }
-    %input.single-line__input{ required: true, name: 'newsletter-form__email', type: 'email', placeholder: 'Enter your email' }
+    %input{ type: 'hidden', name: 'utf8', value: '✓' }
+    %input{ type: 'hidden', name: '_redirect_url', value: page_url }
+    %input.single-line__input{ required: true, name: 'email', type: 'email', placeholder: 'Enter your email' }
     %button.single-line__submit{ type: 'submit'} Sign up

--- a/source/partials/_newsletter-signup.haml
+++ b/source/partials/_newsletter-signup.haml
@@ -1,4 +1,6 @@
-%form.newsletter-form
+%form.newsletter-form{ action: 'https://formkeep.com/f/6d5e9ddb6e0e', method: 'post' }
   %input{ type: 'hidden', name: 'event', value: 'subscribed' }
-  %input#aptible-newsletter-subscription-email.newsletter-form__email{ required: true, name: 'newsletter-form__email', type: 'email', placeholder: 'Email Address' }
+  %input{ type: 'hidden', name: 'utf8', value: '✓' }
+  %input{ type: 'hidden', name: '_redirect_url', value: page_url }
+  %input#aptible-newsletter-subscription-email.newsletter-form__email{ required: true, name: 'email', type: 'email', placeholder: 'Email Address' }
   %button.newsletter-form__submit{ type: 'submit', value: ' ' }

--- a/source/partials/ctas/_demo-cta.haml
+++ b/source/partials/ctas/_demo-cta.haml
@@ -1,7 +1,9 @@
 - cta_label ||= 'Request A Demo'
 - cta_placeholder ||= 'Enter your work email'
 - class_name ||= ''
-%form.signup-cta.request-demo.single-line{ class: class_name }
+%form.signup-cta.request-demo.single-line{ class: class_name, action: 'https://formkeep.com/f/c32c9fb7d6ce' }
+  %input{ type: 'hidden', name: 'utf8', value: '✓' }
+  %input{ type: 'hidden', name: '_redirect_url', value: page_url }
   %input{ type: 'hidden', name: 'event', value: 'gridiron-demo-request' }
-  %input.single-line__input{ type: 'email', name: 'gridiron-demo-request-form__email', placeholder: cta_placeholder, required: true }
+  %input.single-line__input{ type: 'email', name: 'email', placeholder: cta_placeholder, required: true }
   %button.single-line__submit{ type: 'submit' }= cta_label

--- a/source/partials/ctas/_signup-cta.haml
+++ b/source/partials/ctas/_signup-cta.haml
@@ -1,6 +1,8 @@
 - cta_label ||= 'Sign Up'
 - cta_placeholder ||= 'Work Email'
 - class_name ||= ''
-%form.signup-cta.single-line{ action: open_account_href, method: 'get', class: class_name }
+%form.signup-cta.single-line{ action: 'https://formkeep.com/f/f6bad6b94e88', method: 'post', class: class_name }
+  %input{ type: 'hidden', name: 'utf8', value: '✓' }
+  %input{ type: 'hidden', name: '_redirect_url', value: open_account_href }
   %input.single-line__input{ type: 'email', name: 'email', placeholder: cta_placeholder, required: true }
   %button.single-line__submit{ type: 'submit' }= cta_label


### PR DESCRIPTION
Testing @henryhund’s theory that ad brokers are blocking our autopilot form submissions. Post forms to FormKeep where we can collect submitted emails and forward them through our tacking pipeline via zapper.

I've tested these locally, but we'll want to run through them on staging before sending to www. Given FormKeep's `_redirect_url` input and the ability to pass params on through the query string, everything works as it did previously.