### PR TITLE
Name CTA forms for auto-pilot

### DIFF
--- a/source/partials/_newsletter-signup--blog.haml
+++ b/source/partials/_newsletter-signup--blog.haml
@@ -8,5 +8,6 @@
     %input{ type: 'hidden', name: 'event', value: 'subscribed' }
     %input{ type: 'hidden', name: 'utf8', value: '✓' }
     %input{ type: 'hidden', name: '_redirect_url', value: page_url }
+    %input{ type: 'text', name: 'form-name', value: 'Newsletter Signup', style: 'display: none;' }
     %input.single-line__input{ required: true, name: 'email', type: 'email', placeholder: 'Enter your email' }
     %button.single-line__submit{ type: 'submit'} Sign up

--- a/source/partials/_newsletter-signup.haml
+++ b/source/partials/_newsletter-signup.haml
@@ -2,5 +2,6 @@
   %input{ type: 'hidden', name: 'event', value: 'subscribed' }
   %input{ type: 'hidden', name: 'utf8', value: '✓' }
   %input{ type: 'hidden', name: '_redirect_url', value: page_url }
+  %input{ type: 'text', name: 'form-name', value: 'Newsletter Signup', style: 'display: none;' }
   %input#aptible-newsletter-subscription-email.newsletter-form__email{ required: true, name: 'email', type: 'email', placeholder: 'Email Address' }
   %button.newsletter-form__submit{ type: 'submit', value: ' ' }

--- a/source/partials/ctas/_demo-cta.haml
+++ b/source/partials/ctas/_demo-cta.haml
@@ -5,5 +5,6 @@
   %input{ type: 'hidden', name: 'utf8', value: '✓' }
   %input{ type: 'hidden', name: '_redirect_url', value: page_url }
   %input{ type: 'hidden', name: 'event', value: 'gridiron-demo-request' }
+  %input{ type: 'text', name: 'form-name', value: 'Request A Demo', style: 'display: none;' }
   %input.single-line__input{ type: 'email', name: 'gridiron-demo-request-form__email', placeholder: cta_placeholder, required: true }
   %button.single-line__submit{ type: 'submit' }= cta_label

--- a/source/partials/ctas/_signup-cta.haml
+++ b/source/partials/ctas/_signup-cta.haml
@@ -4,5 +4,6 @@
 %form.signup-cta.single-line{ action: 'https://formkeep.com/f/f6bad6b94e88', method: 'post', class: class_name }
   %input{ type: 'hidden', name: 'utf8', value: '✓' }
   %input{ type: 'hidden', name: '_redirect_url', value: open_account_href }
+  %input{ type: 'text', name: 'form-name', value: 'Enclave Signup', style: 'display: none;' }
   %input.single-line__input{ type: 'email', name: 'email', placeholder: cta_placeholder, required: true }
   %button.single-line__submit{ type: 'submit' }= cta_label


### PR DESCRIPTION
Names forms for Autopilot via a form input, not `hidden`, that is hidden with css `display: none;`.

cc @henryhund 