### PR TITLE
Pricing cleanup

### DIFF
--- a/source/index.haml
+++ b/source/index.haml
@@ -1,6 +1,6 @@
 ---
-title: HIPAA Security and Compliance Platform
-description: Powerful security and DevOps tools for engineering teams.
+title: Secure Container Orchestration and Security Management
+description: Powerful security and DevOps tools for software development teams.
 ---
 
 - content_for :header do
@@ -13,9 +13,8 @@ description: Powerful security and DevOps tools for engineering teams.
           %h1.home__heading__title
             Keep your apps, data, and people secure.
           %p.home__heading__summary.heading__summary.heading__summary--sibling
-            Aptible protects your most important assets when the stakes matter
-            most. Thousands of developers use Aptible to secure data and build
-            strong compliance programs.
+            Thousands of developers use Aptible to secure cloud architecture 
+            and build strong security management programs.
           = partial 'partials/ctas/signup-cta', locals: { |
                 cta_label: 'Get Started',                 |
                 cta_placeholder: 'Enter your work email'  |

--- a/source/index.haml
+++ b/source/index.haml
@@ -1,6 +1,6 @@
 ---
-title: Secure Container Orchestration and Security Management
-description: Powerful security and DevOps tools for software development teams.
+title: Security Management and Compliance for Developers
+description: Deploy your app. Design your security management program. Meet the requirements of HIPAA, ISO 27001, SOC 2, PCI, and more.
 ---
 
 - content_for :header do

--- a/source/partials/_signup-demo-request.haml
+++ b/source/partials/_signup-demo-request.haml
@@ -1,5 +1,5 @@
 %ul.signup-cta__incentives
-  %li.signup-cta__incentive Deploy your app
+  %li.signup-cta__incentive Deploy now
   %li.signup-cta__incentive $500 free credit
-  %li.signup-cta__incentive Pay as you go
+  %li.signup-cta__incentive No commitment
   %li.signup-cta__incentive or <a class="" href="mailto:sales@aptible.com">Request a Demo</a>

--- a/source/partials/pricing/_enclave-summary.haml
+++ b/source/partials/pricing/_enclave-summary.haml
@@ -3,7 +3,7 @@
     .pricing-summary__product-icon= partial 'images/enclave.svg'
     .pricing-summary__title Enclave
     .pricing-summary__subtitle
-      Secure container orchestration
+      Container orchestration platform with built-in security and compliance
     .pricing-summary__call-out
       $500 Credit Included
   .pricing-summary__body

--- a/source/partials/pricing/_enclave-summary.haml
+++ b/source/partials/pricing/_enclave-summary.haml
@@ -8,31 +8,20 @@
       $500 Credit Included
   .pricing-summary__body
     .product-price
-      .product-price__name Shared
-      .product-price__exp Development Account
+      .product-price__name Development Account
+      .product-price__exp Shared Instance
       .product-price__price
-        No monthly minimum, no annual contract. Your first $500 is on 
-        us - just pay for what you use after that:
-
-    .pricing-summary__label Enclave Unit Pricing
-    .pricing-rates
-      .pricing-rate
-        .pricing-rate__title App + Database Containers
-        .pricing-rate__rate $0.08/GB/hour
-      .pricing-rate
-        .pricing-rate__title Encrypted Disk
-        .pricing-rate__rate $0.37/GB/month
-      .pricing-rate
-        .pricing-rate__title TLS Endpoints
-        .pricing-rate__rate $0.05/hour
+        $0/month base fee, no commitment. 
+        <br><strong>Your first $500 of resources is on 
+        us.</strong> Just pay for what you use after that.
 
   .pricing-summary__body.pricing-summary__body--bordered
     .product-price
-      .product-price__name Dedicated
+      .product-price__name Production Account
       .product-price__exp
-        Production Account
+        Dedicated Instance
       .product-price__price
-        $999/month base fee w/ annual contract or $1299 month-to-month. 
+        $999/month base fee with annual commitment ($1,299/month with no commitment)<br>
         Just pay for additional usage as you go.
 
     .pricing-summary__checklist
@@ -45,7 +34,25 @@
         %li.pricing-summary__checklist-item
           4 TLS Endpoints
 
+    <br>
+    .pricing-summary__label Enclave Resource Pricing
+    .pricing-rates
+      .pricing-rate
+        .pricing-rate__title App + Database Containers
+        .pricing-rate__rate $0.08/GB/hour
+      .pricing-rate
+        .pricing-rate__title Encrypted Disk
+        .pricing-rate__rate $0.37/GB/month
+      .pricing-rate
+        .pricing-rate__title TLS Endpoints
+        .pricing-rate__rate $0.05/hour
+
   .pricing-summary__body
-    %a.btn.btn--full{ href: open_account_href } Create a Free Dev Account
+    = partial 'partials/ctas/signup-cta', locals: {            |
+                    cta_label: 'Get Started',                             |
+                    cta_placeholder: 'Enter your work email',             |
+                    class_name: 'signup-cta--small signup-cta--no-border' |
+                  }                                                       |
+    / %a.btn.btn--full{ href: open_account_href } Create a Free Dev Account
     - if current_page.path == 'pricing/index.html'
       %a.arrow-link--right{ href: '/pricing/enclave/' } Enclave Pricing Calculator

--- a/source/partials/pricing/_enclave-summary.haml
+++ b/source/partials/pricing/_enclave-summary.haml
@@ -49,7 +49,7 @@
 
   .pricing-summary__body
     = partial 'partials/ctas/signup-cta', locals: {            |
-                    cta_label: 'Get Started',                             |
+                    cta_label: 'Sign up for Free Dev Account',                             |
                     cta_placeholder: 'Enter your work email',             |
                     class_name: 'signup-cta--small signup-cta--no-border' |
                   }                                                       |

--- a/source/partials/pricing/_enclave-summary.haml
+++ b/source/partials/pricing/_enclave-summary.haml
@@ -11,9 +11,10 @@
       .product-price__name Development Account
       .product-price__exp Shared Instance
       .product-price__price
-        $0/month base fee, no commitment. 
-        <br><strong>Your first $500 of resources is on 
-        us.</strong> Just pay for what you use after that.
+        $0/month base fee, no commitment.
+        %p
+          %strong Your first $500 of resources is on us.
+          Just pay for what you use after that.
 
   .pricing-summary__body.pricing-summary__body--bordered
     .product-price

--- a/source/partials/pricing/_enclave-summary.haml
+++ b/source/partials/pricing/_enclave-summary.haml
@@ -3,49 +3,49 @@
     .pricing-summary__product-icon= partial 'images/enclave.svg'
     .pricing-summary__title Enclave
     .pricing-summary__subtitle
-      Docker container orchestration platform with built-in security
-      controls for deploying in regulated industries
+      Secure container orchestration
     .pricing-summary__call-out
-      Free to get started with $500 credit
+      $500 Credit Included
   .pricing-summary__body
     .product-price
-      .product-price__name Production Stack
-      .product-price__exp
-        Dedicated stack, ideal for sensitive production data
+      .product-price__name Shared
+      .product-price__exp Development Account
       .product-price__price
-        $999/month per stack + additional resource usage
-
-    .pricing-summary__checklist
-      .pricing-summary__label Includes
-      %ul.checklist.checklist--blue
-        %li.pricing-summary__checklist-item
-          6GB RAM across as many containers as you need
-        %li.pricing-summary__checklist-item
-          1TB encrypted database disk (including backups)
-        %li.pricing-summary__checklist-item
-          4 TLS/SSL Endpoints
-
-  .pricing-summary__body.pricing-summary__body--bordered
-    .product-price
-      .product-price__name Development Stack
-      .product-price__exp Shared stack, ideal for development or testing
-      .product-price__price
-        No monthly fee, no annual contract. Pay-as-you-go for containers,
-        disk, and endpoint usage.
+        No monthly minimum, no annual contract. Your first $500 is on 
+        us - just pay for what you use after that:
 
     .pricing-summary__label Enclave Unit Pricing
     .pricing-rates
       .pricing-rate
-        .pricing-rate__title App &amp; Database Containers
+        .pricing-rate__title App + Database Containers
         .pricing-rate__rate $0.08/GB/hour
       .pricing-rate
         .pricing-rate__title Encrypted Disk
         .pricing-rate__rate $0.37/GB/month
       .pricing-rate
-        .pricing-rate__title SSL Endpoints
+        .pricing-rate__title TLS Endpoints
         .pricing-rate__rate $0.05/hour
 
+  .pricing-summary__body.pricing-summary__body--bordered
+    .product-price
+      .product-price__name Dedicated
+      .product-price__exp
+        Production Account
+      .product-price__price
+        $999/month base fee w/ annual contract or $1299 month-to-month. 
+        Just pay for additional usage as you go.
+
+    .pricing-summary__checklist
+      .pricing-summary__label Includes
+      %ul.checklist.checklist--blue
+        %li.pricing-summary__checklist-item
+          6 GB App/DB Container RAM
+        %li.pricing-summary__checklist-item
+          1 TB encrypted Database Disk, including automatic backups
+        %li.pricing-summary__checklist-item
+          4 TLS Endpoints
+
   .pricing-summary__body
-    %a.btn.btn--full{ href: open_account_href } Get Started With Enclave
+    %a.btn.btn--full{ href: open_account_href } Create a Free Dev Account
     - if current_page.path == 'pricing/index.html'
-      %a.arrow-link--right{ href: '/pricing/enclave/' } Estimate your Enclave pricing
+      %a.arrow-link--right{ href: '/pricing/enclave/' } Enclave Pricing Calculator

--- a/source/partials/pricing/_need-more.haml
+++ b/source/partials/pricing/_need-more.haml
@@ -7,9 +7,10 @@
       Deploy Enclave in your own AWS account, custom contracts, 
       audit assistance, and volume pricing available.
   .pricing__need-more__action
-    = partial 'partials/ctas/demo-cta', locals: {           |
-      cta_label: 'Have Us Call You',      |
-      class_name: 'pricing-demo-request signup-cta--small'  |
-    }                                                       |
+    %a.btn.signup-cta--small{ href: 'http://contact.aptible.com' } Contact Us
+    / = partial 'partials/ctas/demo-cta', locals: {           |
+    /   cta_label: 'Have Us Call You',      |
+    /   class_name: 'pricing-demo-request signup-cta--small'  |
+    / }                                                       |
 -# When our sign up form is ready, link to it and remove the demo cta
 -# %a.btn{ href: '' } Get in touch about Aptible managed

--- a/source/partials/pricing/_need-more.haml
+++ b/source/partials/pricing/_need-more.haml
@@ -2,13 +2,13 @@
 -# previous element should have `position: relative; z-index: 1;`
 .content.hero-gradient--angled.pricing__need-more
   .grid-container
-    .pricing__need-more__title Need Something More?
+    .pricing__need-more__title Need More?
     .pricing__need-more__subtitle
-      Get custom MSAs, BAAs, SLAs, regulatory and customer audit assistance,
-      custom support plans and/or volume pricing on usage.
+      Deploy Enclave in your own AWS account, custom contracts, 
+      audit assistance, and volume pricing available.
   .pricing__need-more__action
     = partial 'partials/ctas/demo-cta', locals: {           |
-      cta_label: 'Get in touch about Aptible Managed',      |
+      cta_label: 'Have Us Call You',      |
       class_name: 'pricing-demo-request signup-cta--small'  |
     }                                                       |
 -# When our sign up form is ready, link to it and remove the demo cta

--- a/source/pricing/index.haml
+++ b/source/pricing/index.haml
@@ -1,5 +1,5 @@
 ---
-title: Simple, flexible, transparent Pricing
+title: Pricing
 description: Transparent pricing details for Enclave, Aptible's Docker container
              orchestration platform, and Gridiron, Aptible's compliance and
              data security management platform built for developers.
@@ -12,7 +12,7 @@ description: Transparent pricing details for Enclave, Aptible's Docker container
     .grid-container.pricing-page-header
       .centered-header.centered-header--wide
         %h1.heading__title Aptible Pricing
-        %h2.heading__subtitle Simple. Flexible. Transparent.
+        %h2.heading__subtitle Simple, transparent, scalable
 
 .content
   .pricing-summaries.grid-container
@@ -25,43 +25,43 @@ description: Transparent pricing details for Enclave, Aptible's Docker container
         .pricing-summary__product-icon= partial 'images/gridiron.svg'
         .pricing-summary__title Gridiron
         .pricing-summary__subtitle
-          Compliance and data security management platform built for developers
+          Security and compliance management for software development teams
 
       .pricing-summary__body
         .product-price
           .product-price__name Gridiron
-          .product-price__price Starting at $2,500/month with annual contract
+          .product-price__price Starting at $2,499/month with annual contract
 
         .pricing-summary__checklist.pricing-summary--fill
           .pricing-summary__label Includes
           %ul.checklist.checklist--blue
             %li.pricing-summary__checklist-item
-              Access to one compliance protocol e.g. HIPAA, SOC 2, or ISO 27001
+              First compliance protocol (HIPAA, SOC 2, or ISO 27001)
             %li.pricing-summary__checklist-item
-              Basic compliance and security training for up to 25 team members
+              2 Admin seats for security leads
             %li.pricing-summary__checklist-item
-              Advanced compliance and security training for up to 10 team members
+              10 Advanced seats for developers, ops team members
             %li.pricing-summary__checklist-item
-              Additional compliance protocols and training users available
+              20 Basic seats for normal workforce members
 
-        -# Keeping this here to avoid CSS spacing work when we add it.
-        -# Currently `visibility: hidden` to keep its placement in the DOM
-        .pricing-summary--hidden
-          .pricing-summary__label ********
-          .pricing-rates
-            .pricing-rate
-              .pricing-rate__title ********
-              .pricing-rate__rate ********
-            .pricing-rate
-              .pricing-rate__title ********
-              .pricing-rate__rate ********
-            .pricing-rate
-              .pricing-rate__title ********
-              .pricing-rate__rate ********
+        .pricing-summary__label Extras
+        .pricing-rates
+          .pricing-rate
+            .pricing-rate__title Basic Seat
+            .pricing-rate__rate $199/year
+          .pricing-rate
+            .pricing-rate__title Advanced Seat
+            .pricing-rate__rate $499/year
+          .pricing-rate
+            .pricing-rate__title Admin Seat
+            .pricing-rate__rate $999/year
+          .pricing-rate
+            .pricing-rate__title Additional Protocol
+            .pricing-rate__rate $7499/year
 
       .pricing-summary__body
         = partial 'partials/ctas/demo-cta', locals: {             |
-            cta_label: 'Request A Demo',                          |
+            cta_label: 'Have Us Call You',                          |
             class_name: 'pricing-demo-request signup-cta--small'  |
           }                                                       |
 

--- a/source/pricing/index.haml
+++ b/source/pricing/index.haml
@@ -60,10 +60,11 @@ description: Transparent pricing details for Enclave, Aptible's Docker container
             .pricing-rate__rate $7499/year
 
       .pricing-summary__body
-        = partial 'partials/ctas/demo-cta', locals: {             |
-            cta_label: 'Have Us Call You',                          |
-            class_name: 'pricing-demo-request signup-cta--small'  |
-          }                                                       |
+        %a.btn.btn--full{ href: 'http://contact.aptible.com' } Contact Us
+        / = partial 'partials/ctas/demo-cta', locals: {             |
+        /     cta_label: 'Have Us Call You',                          |
+        /     class_name: 'pricing-demo-request signup-cta--small'  |
+        /   }                                                       |
 
   = partial 'pricing/need-more'
 

--- a/source/stylesheets/_pricing.scss
+++ b/source/stylesheets/_pricing.scss
@@ -145,6 +145,9 @@
     font-size: 14px;
     font-weight: $regular;
   }
+  .signup-cta--small {
+    margin-left: 0;
+  }
 }
 
 .pricing-summary__actions {
@@ -178,7 +181,7 @@
 }
 
 .pricing-summary--fill {
-  height: 205px;
+  height: 250px;
 }
 
 .pricing-summary__body--bordered {


### PR DESCRIPTION
This supersedes the changes in https://github.com/aptible/www.aptible.com/pull/520

This is not yet publishable. I'm still working on language, and there are some styling issues.

I made some tweaks to the changes @chasballew proposed. The biggest change I made was to the signup ctas on pricing. Please note that I'm linking the "contact us" or type ctas to http://contact.aptible.com. This is clearly not ideal given that it is a support form. However, it is the only contact page we have, and I believe, if memory serves, @shahkader is OK with receiving these types of requests through support. Hopefully, we will launch our new contact us page soon and be able to direct this type of traffic there.

This PR needs further language review before it is approved to go out. 

The styling issue that needs to be improved is alignment between Enclave and Gridiron on the pricing page, as well as left alignment of the Enclave CTA. @gib can you help with this? See here:

![screen shot 2017-08-28 at 6 03 49 pm](https://user-images.githubusercontent.com/3512705/29795690-4d4cee64-8c1b-11e7-912e-2496e1c8d5bf.png)

I may make additional tweaks, but this is the biggest thing that needs to be ironed out now.