### PR TITLE
Allow links in the changelog index

### DIFF
--- a/helpers/contentful_helpers.rb
+++ b/helpers/contentful_helpers.rb
@@ -19,7 +19,8 @@ module ContentfulHelpers
           'product' => yml[:product],
           'section' => 'Blog',
           'type' => yml[:type],
-          'hackernews_link' => yml[:hackernews_link]
+          'hackernews_link' => yml[:hackernews_link],
+          'show_body_in_index' => yml[:show_body_in_index]
         }
       }]
     end,

--- a/source/partials/_changelog-list-item.haml
+++ b/source/partials/_changelog-list-item.haml
@@ -1,6 +1,12 @@
-%a.changelog-entry{ href: blog_post_href(post) }
+.changelog-entry
   %span.changelog-entry__product
   %span.changelog-entry__info
     %span.changelog-entry__date= display_date(post.data.posted)
     %span.changelog-entry__title= post.data.title
-    %span.changelog-entry__summary= post.data.excerpt
+    - if post.data.show_body_in_index
+      %div.changelog-entry__summary
+        = find_and_preserve do
+          = post.render({ layout: false })
+    - else
+      %span.changelog-entry__summary= post.data.excerpt
+    %a.arrow-link--right.dbl-arrow-link--right{ href: blog_post_href(post) } Read more

--- a/source/stylesheets/_changelog.scss
+++ b/source/stylesheets/_changelog.scss
@@ -42,4 +42,8 @@
 .changelog-entry__summary {
   color: $dark-blue-steel;
   display: block;
+
+  p {
+    margin: 0px;
+  }
 }

--- a/spec/fixtures/contentful/blog/introducing-direct-docker-image-deploy/output.md
+++ b/spec/fixtures/contentful/blog/introducing-direct-docker-image-deploy/output.md
@@ -11,6 +11,7 @@ product: enclave
 section: Blog
 type: blog post
 hackernews_link: https://news.ycombinator.com/item?id=13759706
+show_body_in_index:
 ---
 
 We’re proud to announce that you can now deploy apps on Enclave directly from a Docker image, bypassing Enclave’s traditional git-based deployment process.

--- a/spec/fixtures/contentful/blog/vulnerability-scanning-for-your-dependencies-why-and-how/output.md
+++ b/spec/fixtures/contentful/blog/vulnerability-scanning-for-your-dependencies-why-and-how/output.md
@@ -11,6 +11,7 @@ product: enclave
 section: Blog
 type: blog post
 hackernews_link:
+show_body_in_index:
 ---
 
 In a world where application dependency graphs are deeper than ever, secure engineering means more than securing your own software: tracking vulnerabilities in your dependencies is just as important.

--- a/spec/fixtures/contentful/changelog/managed-https-endpoints-now-support-internal-endpoints/input.yml
+++ b/spec/fixtures/contentful/changelog/managed-https-endpoints-now-support-internal-endpoints/input.yml
@@ -59,3 +59,4 @@
   :slug: thomas
   :email: thomas@aptible.com
   :gravatar: https://s.gravatar.com/avatar/f532cf09084eb963bfc913867fff2258
+:show_body_in_index: true

--- a/spec/fixtures/contentful/changelog/managed-https-endpoints-now-support-internal-endpoints/output.md
+++ b/spec/fixtures/contentful/changelog/managed-https-endpoints-now-support-internal-endpoints/output.md
@@ -10,6 +10,7 @@ product: enclave
 section: Blog
 type: changelog post
 hackernews_link:
+show_body_in_index: true
 ---
 
 We’re happy to announce that [Managed HTTPS](https://www.aptible.com/blog/managed-https/) is now available on Enclave for Internal Endpoints (in addition to External Endpoints, which were supported from day 1).

--- a/spec/helpers/contentful_helpers_spec.rb
+++ b/spec/helpers/contentful_helpers_spec.rb
@@ -1,70 +1,91 @@
 require 'spec_helper'
+require 'pathname'
 
 describe ContentfulHelpers do
   describe 'markdown_map' do
-    let(:fixtures_root) do
+    def self.fixtures_root
       File.join(File.dirname(__FILE__), '..', 'fixtures/contentful')
     end
 
-    it 'correctly translates Blog resources to Markdown' do
+    def self.relpath(fixture)
+      fixtures_pathname = Pathname.new(fixtures_root)
+      Pathname.new(fixture).relative_path_from(fixtures_pathname)
+    end
+
+    context 'correctly translates Blog resources to Markdown' do
       Dir.glob(File.join(fixtures_root, 'blog', '*')).each do |fixture|
-        yaml = File.read(File.join(fixture, 'input.yml'))
-        expected_markdown = File.read(File.join(fixture, 'output.md'))
-        markdown_map = described_class.markdown_map('blogPost', yaml)
+        it "with fixture: #{relpath(fixture)}" do
+          yaml = File.read(File.join(fixture, 'input.yml'))
+          expected_markdown = File.read(File.join(fixture, 'output.md'))
+          markdown_map = described_class.markdown_map('blogPost', yaml)
 
-        markdown_path = "source/blog/#{File.basename(fixture)}.md"
-        expect(markdown_map[markdown_path].chomp).to eq expected_markdown.chomp
+          markdown_path = "source/blog/#{File.basename(fixture)}.md"
+          expect(markdown_map[markdown_path].chomp)
+            .to eq(expected_markdown.chomp)
+        end
       end
     end
 
-    it 'correctly translates Changelog resources to Markdown' do
+    context 'correctly translates Changelog resources to Markdown' do
       Dir.glob(File.join(fixtures_root, 'changelog', '*')).each do |fixture|
-        yaml = File.read(File.join(fixture, 'input.yml'))
-        expected_markdown = File.read(File.join(fixture, 'output.md'))
-        markdown_map = described_class.markdown_map('blogPost', yaml)
+        it "with fixture: #{relpath(fixture)}" do
+          yaml = File.read(File.join(fixture, 'input.yml'))
+          expected_markdown = File.read(File.join(fixture, 'output.md'))
+          markdown_map = described_class.markdown_map('blogPost', yaml)
 
-        markdown_path = "source/changelog/#{File.basename(fixture)}.md"
-        expect(markdown_map[markdown_path].chomp).to eq expected_markdown.chomp
+          markdown_path = "source/changelog/#{File.basename(fixture)}.md"
+          expect(markdown_map[markdown_path].chomp)
+            .to eq(expected_markdown.chomp)
+        end
       end
     end
 
-    it 'correctly translates Learn resources to Markdown' do
+    context 'correctly translates Learn resources to Markdown' do
       Dir.glob(File.join(fixtures_root, 'learn', '*')).each do |fixture|
-        yaml = File.read(File.join(fixture, 'input.yml'))
-        expected_markdown = File.read(File.join(fixture, 'output.md'))
-        markdown_map = described_class.markdown_map('resourcePage', yaml)
+        it "with fixture: #{relpath(fixture)}" do
+          yaml = File.read(File.join(fixture, 'input.yml'))
+          expected_markdown = File.read(File.join(fixture, 'output.md'))
+          markdown_map = described_class.markdown_map('resourcePage', yaml)
 
-        markdown_path = "source/learn/#{File.basename(fixture)}.md"
-        expect(markdown_map[markdown_path].chomp).to eq expected_markdown.chomp
+          markdown_path = "source/learn/#{File.basename(fixture)}.md"
+          expect(markdown_map[markdown_path].chomp)
+            .to eq(expected_markdown.chomp)
+        end
       end
     end
 
-    it 'correctly translates Webinar resources to Markdown' do
+    context 'correctly translates Webinar resources to Markdown' do
       Dir.glob(File.join(fixtures_root, 'webinars', '*')).each do |fixture|
-        yaml = File.read(File.join(fixture, 'input.yml'))
-        expected_markdown = File.read(File.join(fixture, 'output.md'))
-        expected_transcript = File.read(File.join(fixture,
-                                                  '_output-transcript.md'))
-        markdown_map = described_class.markdown_map('resourcePage', yaml)
+        it "with fixture: #{relpath(fixture)}" do
+          yaml = File.read(File.join(fixture, 'input.yml'))
+          expected_markdown = File.read(File.join(fixture, 'output.md'))
+          expected_transcript = File.read(File.join(fixture,
+                                                    '_output-transcript.md'))
+          markdown_map = described_class.markdown_map('resourcePage', yaml)
 
-        basename = File.basename(fixture)
-        markdown_path = "source/resources/#{basename}.md"
-        transcript_path = "source/resources/_#{basename}-transcript.md"
+          basename = File.basename(fixture)
+          markdown_path = "source/resources/#{basename}.md"
+          transcript_path = "source/resources/_#{basename}-transcript.md"
 
-        expect(markdown_map[markdown_path].chomp).to eq expected_markdown.chomp
-        expect(markdown_map[transcript_path].chomp).to eq \
-          expected_transcript.chomp
+          expect(markdown_map[markdown_path].chomp)
+            .to eq(expected_markdown.chomp)
+          expect(markdown_map[transcript_path].chomp)
+            .to eq(expected_transcript.chomp)
+        end
       end
     end
 
-    it 'correctly translates other resources to Markdown' do
+    context 'correctly translates other resources to Markdown' do
       Dir.glob(File.join(fixtures_root, 'resources', '*')).each do |fixture|
-        yaml = File.read(File.join(fixture, 'input.yml'))
-        expected_markdown = File.read(File.join(fixture, 'output.md'))
-        markdown_map = described_class.markdown_map('resourcePage', yaml)
+        it "with fixture: #{relpath(fixture)}" do
+          yaml = File.read(File.join(fixture, 'input.yml'))
+          expected_markdown = File.read(File.join(fixture, 'output.md'))
+          markdown_map = described_class.markdown_map('resourcePage', yaml)
 
-        markdown_path = "source/resources/#{File.basename(fixture)}.md"
-        expect(markdown_map[markdown_path].chomp).to eq expected_markdown.chomp
+          markdown_path = "source/resources/#{File.basename(fixture)}.md"
+          expect(markdown_map[markdown_path].chomp)
+            .to eq(expected_markdown.chomp)
+        end
       end
     end
   end


### PR DESCRIPTION
Two changes here:

- Added a flag in Contentful (ran this by Gib) to indicate that a given
  Changelog entry's body (as opposed to its excerpt) should be rendered
  in the list view. This will let us use links there, since the
  Changelog entry's body is HTML.
- Removed the link surrounding each chngelog item in the index (because
  that prevents us from having links in it), and replaced them with a
  "Read More" link at the end.

Even though there is nothing more to read, I opted to retain the "Read
More" link for changelog posts that are displayed in full (i.e. those
that have the flag set) in the changelog index, for two reasons:

- Consistency.
- So users can access a URL for the post to share.

I'm totally to reverting that last decision, or changing the copy (e.g.
to say "to the post" instead of "read more").

---

It looks like this:

![localhost-4567-blog-](https://user-images.githubusercontent.com/1737686/30223560-aa0c49b6-94cb-11e7-9d49-ad4abd2b391d.png)

cc @gib @sandersonet 

fyi @fancyremarker 