### PR TITLE
Updating language to clarify we are multi-protocol (and clean up page titles, etc.)

### DIFF
--- a/source/aws-vs-aptible.haml
+++ b/source/aws-vs-aptible.haml
@@ -1,5 +1,5 @@
 ---
-title: 'HIPAA-Compliant Deployment: AWS vs Aptible'
+title: 'HIPAA Compliant and ISO 27001 Certified Container Orchestration: AWS vs. Aptible Enclave'
 ---
 
 - content_for :header do
@@ -11,7 +11,7 @@ title: 'HIPAA-Compliant Deployment: AWS vs Aptible'
         %img{ src: '/images/product-stack-2x.png', style: 'width: 50%' }
 
       .grid-item
-        %h2.heading__subtitle HIPAA-Compliant Deployment
+        %h2.heading__subtitle Secure, Compliant Container Orchestration
         %h1.heading__title AWS vs Aptible
         .heading__subtitle--strong
           Build a great app.<br>

--- a/source/company/index.haml
+++ b/source/company/index.haml
@@ -19,9 +19,9 @@ title: About Aptible
 
       %p.summary--single-center
         We are transforming the experience of building private, secure
-        software systems in regulated industries. We are starting in digital
+        software systems in regulated industries. We started in digital
         health because the American healthcare system is broken and we want to
-        empower those who can fix it. If you want to make a meaningful
+        empower those who can fix it. We're now working with companies of all industries to secure sensitive data. If you want to make a meaningful
         difference, join our team.
 
   .openings.grid-container.grid--3up

--- a/source/enclave.haml
+++ b/source/enclave.haml
@@ -1,9 +1,7 @@
 ---
-title: Enclave - Secure DevOps
-description: Aptible Enclave is a container platform that simplifies secure
-             deployment and development best practices. Unlike using IaaS
-             directly, Enclave is turnkey for regulated apps, and includes
-             robust DevOps and security automation.
+title:  Container Orchestration Platform with Built-in Security Controls for Complying with HIPAA, ISO 27001, SOC 2, NIST 800-53, and many others - Aptible Enclave&reg;
+description: Aptible Enclave is a container orchestration platform built for developers that automates security best practices and controls needed for deploying and scaling Dockerized apps in regulated industries.
+
 ---
 - content_for :header do
   %header.aptible-header.hero-gradient--angled.aptible-header--with-breadcrumbs.aptible-header--bottom-grid

--- a/source/faq/index.md
+++ b/source/faq/index.md
@@ -187,7 +187,7 @@ You must have a Business Associate Agreement (BAA) in place with Aptible before 
 --------
 
 
-**What else might I need to comply with HIPAA?**
+**What else might I need to comply with HIPAA or meet other security and compliance requirements?**
 
 If you are deployed on Enclave and using Gridiron for security management, you may also want:
 
@@ -200,4 +200,6 @@ If you are deployed on Enclave and using Gridiron for security management, you m
 
 **Is Aptible audited?**
 
-Yes, Aptible has passed hundreds of security and compliance audits alongside our customers at the largest entities in healthcare. In the past year we have passed audits with Kaiser Permanente, MD Anderson, UnitedHealth Group, Johns Hopkins, Stanford, and many others. We are currently undergoing ISO 27001 and SOC 2 certification.
+Yes, Aptible has passed hundreds of security and compliance audits alongside our customers at the largest entities in healthcare. In the past year we have passed audits with Kaiser Permanente, MD Anderson, UnitedHealth Group, Johns Hopkins, Stanford, and many others. 
+
+We have achieved ISO 27001 certification and we are working towards our SOC 2 certification, as well.

--- a/source/gridiron.haml
+++ b/source/gridiron.haml
@@ -1,7 +1,7 @@
 ---
 # These variables are used in the page title and meta tags
-title: "Gridiron: HIPAA Compliance and Security Management"
-description: Aptible Gridiron helps engineering teams set up and run robust
+title: "Security Management Programs for Complying with HIPAA, ISO 27001, SOC 2, NIST 800-53, and many others - Aptible Gridiron&reg;"
+description: Aptible Gridiron helps developer teams set up and run robust
              security and compliance programs.
 ---
 
@@ -138,7 +138,7 @@ description: Aptible Gridiron helps engineering teams set up and run robust
   .footer__signup.grid-container.grid--single-center
     .footer__signup__hgroup
       %h2.footer__signup-title
-        Get your team HIPAA-compliant in days, not months
+        Design and build your security management program in days, not months
     .footer__signup-form
       = partial 'partials/ctas/demo-cta', locals: {   |
             cta_label: 'Request A Demo',              |


### PR DESCRIPTION
This supersedes https://github.com/aptible/www.aptible.com/pull/512

In this pull request, I improved site language, page titles, etc. to better match our value prop and to include multiple protocols. Here's what I did:

1. Made sure none of our pages were exclusively focused on healthcare and HIPAA.
2. Improved Enclave and Gridiron page titles to optimize for display in search results and when the pages are shared, and to better capture our value prop.
3. Added the registration symbol &reg; to our Gridiron and Enclave page titles.

cc: @chasballew if you'd like to take a look at the changes, I'd be honored to hear any feedback.

@gib These are all text changes, so with your approval, I'll merge. I don't think we need to wait for @chasballew to review. If he has any feedback that we need to act on, I'll create an additional PR. That said, I'm certain that the changes here are improvements from the status quo, so I'm excited to get this live.

