### PR TITLE
Gridiron Changelog and markdown rendered lists

### DIFF
--- a/source/partials/_changelog-list-item.haml
+++ b/source/partials/_changelog-list-item.haml
@@ -1,5 +1,5 @@
 .changelog-entry
-  %span.changelog-entry__product
+  %span.changelog-entry__product{ data: { product: post.data.product } }
   %span.changelog-entry__info
     %span.changelog-entry__date= display_date(post.data.posted)
     %span.changelog-entry__title= post.data.title

--- a/source/stylesheets/_blog.scss
+++ b/source/stylesheets/_blog.scss
@@ -77,26 +77,6 @@
 .post__changelog-entry {
   display: flex;
 }
-.changelog-entry__product {
-  content: '';
-  font-size: 12px;
-  font-weight: $semibold;
-  margin-right: 20px;
-  text-transform: uppercase;
-  &::after {
-    border: 1px solid $blue;
-    border-radius: 3px;
-    padding: 8px 10px;
-    color: $blue;
-    content: "enclave";
-  }
-}
-
-.changelog-entry__product--gridiron::after {
-  border-color: $purple;
-  color: $purple;
-  content: "gridiron";
-}
 
 .changelog-entry__summary {
 

--- a/source/stylesheets/_changelog.scss
+++ b/source/stylesheets/_changelog.scss
@@ -21,6 +21,28 @@
   line-height: 3;
 }
 
+.changelog-entry__product {
+  content: '';
+  font-size: 12px;
+  font-weight: $semibold;
+  margin-right: 20px;
+  text-transform: uppercase;
+  &::after {
+    border-radius: 3px;
+    border: 1px solid $blue;
+    color: $blue;
+    content: "enclave";
+    display: inline-block;
+    text-align: center;
+    width: 80px;
+  }
+  &[data-product='gridiron']::after {
+    border-color: $purple;
+    color: $purple;
+    content: "gridiron";
+  }
+}
+
 .changelog-entry__info {
   flex-grow: 1;
 }

--- a/source/stylesheets/base/_typography.scss
+++ b/source/stylesheets/base/_typography.scss
@@ -118,7 +118,7 @@ hr {
     img {
       margin: 50px 0 34px 0;
     }
-    & + pre {
+    & + pre, & + ul, & + ol {
       margin-top: 10px;
     }
   }


### PR DESCRIPTION
Leverages an existing style for gridiron changelog entries by adding a product value attribute.

Fixes some missing spacing for paragraphs and adjacent lists in markdown rendered content.