### PR TITLE
updated about page

### DIFF
--- a/source/company/index.haml
+++ b/source/company/index.haml
@@ -2,20 +2,20 @@
 title: About
 ---
 - content_for :header do
-  %header.aptible-header.hero-gradient--angled.aptible-header--bottom-grid
+  %header.aptible-header.hero-gradient--angled
     = partial 'partials/main-nav'
-    .grid-container.grid--single-center{ :style => "padding-top: 1%; padding-bottom: 1%; max-width: 300px;" }
-      %h1.heading
+    .about-heading.heading--single-center.heading--condensed
+      %h1.heading__title.heading__title--no-hr.heading__title--centered
         About Us
-      %p.summary{ :style => "font-weight:bold" }
+      %p.heading__summary--single-center.heading__summary--light-blue-gray
         Aptible is a distributed company that helps developers secure data and applications online.
 
 .content
   .grid-container.grid--2up
+    .grid-item.grid-item--adjacent
+      %h2.heading Who We Are
+  .grid-container.grid--2up
     .grid-item
-      %h2.heading
-        Who We Are
-
       %p.summary
         Aptible was founded in 2013 with the goal of creating a more secure internet by helping developers excel at data security and compliance.
       %p.summary
@@ -24,11 +24,12 @@ title: About
         Aptible builds tools that help developers implement data security best practices and enforce compliance requirements.
       %p.summary
         Aptible works closely with thousands of developers at hundreds of companies, including many startups. The Aptible team is fully remote and is made up of engineers, lawyers, and security and operations experts. Aptible’s investors include Y Combinator, Rock Health, Maverick, WTI, and GGV Capital.
-    .grid-item{ style: "display: inline-block;height: 100%; vertical-align: middle;"}
-      %img{ src: '/images/company/aptible-team-portrait.jpg', style: ""}
-  .grid-container.grid--single-center
     .grid-item
-      %h2.heading--single--center
+      %img{ src: '/images/company/aptible-team-portrait.jpg', style: ""}
+
+  .grid-container
+    .grid-item
+      %h2.heading--single-center
         Help build the future of privacy and security on the web.
       .openings.grid-container.grid--2up
         = partial 'loading-indicator'

--- a/source/company/index.haml
+++ b/source/company/index.haml
@@ -1,28 +1,34 @@
 ---
-title: About Aptible
+title: About
 ---
 - content_for :header do
   %header.aptible-header.hero-gradient--angled.aptible-header--bottom-grid
     = partial 'partials/main-nav'
-
-    .grid-container
-      %h3.heading__subtitle Our Mission
-      %h2.heading__title
-        We help our customers work safely with the most meaningful,
-        sensitive data in highly regulated industries.
+    .grid-container.grid--single-center{ :style => "padding-top: 1%; padding-bottom: 1%; max-width: 300px;" }
+      %h1.heading
+        About Us
+      %p.summary{ :style => "font-weight:bold" }
+        Aptible is a distributed company that helps developers secure data and applications online.
 
 .content
+  .grid-container.grid--2up
+    .grid-item
+      %h2.heading
+        Who We Are
+
+      %p.summary
+        Aptible was founded in 2013 with the goal of creating a more secure internet by helping developers excel at data security and compliance.
+      %p.summary
+        The Internet is radically transforming massive sectors of the global economy, like healthcare, industry, agriculture, and banking. In the process, more sensitive data is moving online, and, as we are constantly reminded, data security is hard.
+      %p.summary
+        Aptible builds tools that help developers implement data security best practices and enforce compliance requirements.
+      %p.summary
+        Aptible works closely with thousands of developers at hundreds of companies, including many startups. The Aptible team is fully remote and is made up of engineers, lawyers, and security and operations experts. Aptible’s investors include Y Combinator, Rock Health, Maverick, WTI, and GGV Capital.
+    .grid-item{ style: "display: inline-block;height: 100%; vertical-align: middle;"}
+      %img{ src: '/images/company/aptible-team-portrait.jpg', style: ""}
   .grid-container.grid--single-center
-    .grid-item.grid-item--adjacent
-      %h2.heading--single-center
+    .grid-item
+      %h2.heading--single--center
         Help build the future of privacy and security on the web.
-
-      %p.summary--single-center
-        We are transforming the experience of building private, secure
-        software systems in regulated industries. We started in digital
-        health because the American healthcare system is broken and we want to
-        empower those who can fix it. We're now working with companies of all industries to secure sensitive data. If you want to make a meaningful
-        difference, join our team.
-
-  .openings.grid-container.grid--3up
-    = partial 'loading-indicator'
+      .openings.grid-container.grid--2up
+        = partial 'loading-indicator'

--- a/source/stylesheets/base/_typography.scss
+++ b/source/stylesheets/base/_typography.scss
@@ -151,6 +151,13 @@ hr {
   max-width: 85%;
 }
 
+.heading--condensed {
+  max-width: 475px;
+  @media screen and (max-width: $tablet-portrait) {
+    max-width: 90%;
+  }
+}
+
 .summary--single-center {
   color: $light-blue-gray;
   font-size: 24px;

--- a/source/stylesheets/components/_header.scss
+++ b/source/stylesheets/components/_header.scss
@@ -64,6 +64,10 @@
   @extend .with-hr
 }
 
+.heading__title--no-hr {
+  &::after { display: none; }
+}
+
 .heading__title--centered {
   color: $white;
   font-size: 40px;


### PR DESCRIPTION
Hi @gib @sandersonet --

I wanted to get our new About Aptible text up quickly, with a corollary goal of slightly improving the look of our About page. I made some changes for text sizing, added in our team portrait, and centered the job postings section in the bottom.

I'm aware that the design for this about page isn't perfect, certainly isn't anywhere near @sandersonet quality. However, in an effort to improve our communication with job prospects, I wanted to get this up as quickly as possible. I'm interested in feedback and improvements, especially:

- [ ] 1. I failed at getting the team picture vertically aligned. I always fail at vertical alignment. Why is it so hard? Beyond that, I'm hoping for suggestions on how to make the team portrait look a little jazzier... it's just a jpg sitting in an empty container right now.
- [ ] 2. I'm not sure that the `.grid-bottom` style in the header is great to use here, but it was the most interesting available style that I was aware of.
- [ ] 3. I think the font treatments could use some tweaking.
- [ ] 4. We should fix the alignment of the text within the job posting boxes.
- [ ] 5. If we have > 2 job postings, will they fill down the page? Or with the style used `.grid-container.grid--2up` will it only show 2 postings, regardless of how many we actually have?

All this being said, I think the PR as it stands IS an improvement over our current About page. So I don't want to hold this up if design/CSS tweaks are going to take more than 1 business day. That is, unless you two disagree that this is an improvement on the current page.

![screen shot 2017-10-12 at 6 09 28 pm](https://user-images.githubusercontent.com/3512705/31521707-8534d8de-af78-11e7-8828-161da3bdb514.png)
