### PR TITLE
Link resource cover images

### DIFF
--- a/source/layouts/resource.haml
+++ b/source/layouts/resource.haml
@@ -1,6 +1,7 @@
 - resource = current_page.data
 - @title = resource.title
 - @description = resource.meta_description || resource.snippet
+- ref_doc = if resource.documents.length == 1 then resource.documents[0] else nil end
 
 - content_for :header do
   %header.aptible-header.hero-gradient--angled
@@ -23,7 +24,11 @@
 
         - if resource.cover_image
           .resource-article__cover-image{ style: "background-image: url(#{resource.cover_image.url})" }
-            %img{ src: resource.cover_image.url }
+            - if ref_doc
+              %a{ href: ref_doc.path, title: ref_doc.title, target: '_blank', rel: 'noopener noreferrer' }
+                %img{ src: resource.cover_image.url }
+            - else
+              %img{ src: resource.cover_image.url }
 
         - if resource.webinar_video_link
           %p.text-center

--- a/source/stylesheets/components/_resources.scss
+++ b/source/stylesheets/components/_resources.scss
@@ -229,6 +229,9 @@
   img {
     visibility: hidden;
   }
+  a {
+    display: block;
+  }
 }
 
 //
@@ -269,6 +272,7 @@
     position: absolute;
     text-align: center;
     text-transform: uppercase;
+    transition: color .25s ease-in-out;
     width: 100%;
   }
   svg {


### PR DESCRIPTION
Resources should include documents, a contentful object type, that references PDFs that are committed to the repo.

If there is a single document, I assume it is represented by a cover image and link the image to the document as a temporary solution to our current Enclave Architecture Reference issues (see https://trello.com/c/ngDQnkPp/137-resource-cover-image-improve-ux)

The image cover image can also be removed.