### PR TITLE
Nav additions and Image URLs

### DIFF
--- a/source/partials/_nav-items.haml
+++ b/source/partials/_nav-items.haml
@@ -13,10 +13,29 @@
         .nav-item__title Gridiron
         .nav-item__desc
           Security and compliance management for software development teams
+    .nav-item.nav-item--group
+      .nav-item__title Solutions
+      .nav-item__sub-nav--full
+        %a.sub-nav__item--full{ href: '/enclave/managed-host-intrusion-detection-system/' }
+          Managed Host-level Intrusion Detection
+        %a.sub-nav__item--full{ href: '/compliance/iso-27001-certification/' }
+          ISO 27001 Certification
     %a.nav-item.nav-item--endcap{ href: '/pricing/', class: active_nav_item('pricing') }
       .nav-item__meta
         .nav-item__title Pricing
         .nav-item__desc Simple and transparent pricing
+
+.nav-item.nav-parent{ tabindex: 0, style: 'display: none;' }
+  %a.nav-item.nav-item--parent{ href: '#' } Solutions
+  %nav.nav-list__child-nav.nav-list__child-nav--developers
+    %a.nav-item.nav-item--child.nav-item--with-arrow{ href: '/enclave/managed-host-intrusion-detection-system/' }
+      .nav-item__meta
+        .nav-item__title Managed Host-level Intrustion Detection
+        .nav-item__desc Security events collected via OSSEC, analyzed, and trigger an Aptible incident response.
+    %a.nav-item.nav-item--child.nav-item--with-arrow.nav-item__sub-nav--endcap{ href: '/compliance/iso-27001-certification/' }
+      .nav-item__meta
+        .nav-item__title ISO 27001 Certification
+        .nav-item__desc Learn what this means and how software development teams can get certified.
 
 .nav-item.nav-parent{ tabindex: 0 }
   %a.nav-item.nav-item--parent{ href: '#' } Developers

--- a/source/stylesheets/_cards.scss
+++ b/source/stylesheets/_cards.scss
@@ -198,7 +198,7 @@
 
 .img-card__image {
   align-items: center;
-  background-image: url(/images/grid-bg-fade.png),
+  background-image: image-url('grid-bg-fade.png'),
                     linear-gradient(180deg, #172231 0%, #172231 20%, #421832 100%);
   background-position: 50% 25%;
   background-size: 300% 300%, 100%;

--- a/source/stylesheets/_customers.scss
+++ b/source/stylesheets/_customers.scss
@@ -25,7 +25,7 @@
 
 .case-study--thread {
   background-color: #eb3927;
-  background-image: url(/images/customers/thread-bg.png);
+  background-image: image-url('customers/thread-bg.png');
   background-repeat: no-repeat;
   background-size: cover;
   background-position: top center;
@@ -38,7 +38,7 @@
 
 .case-study--telepharm {
   background-color: #3aa9e0;
-  background-image: url(/images/customers/telepharm-bg.png);
+  background-image: image-url('customers/telepharm-bg.png');
   background-repeat: no-repeat;
   background-size: cover;
   background-position: top center;
@@ -55,7 +55,7 @@
 //
 .pride-study__hero {
   background-color: #ee6624;
-  background-image: url(/images/customers/stories/pride-study-bg.png);
+  background-image: image-url('customers/stories/pride-study-bg.png');
   background-position: center 20%;
   background-repeat: no-repeat;
   background-size: cover;
@@ -143,7 +143,7 @@
 }
 .pride-study__thread {
   background-color: #2f323a;
-  background-image: url(/images/customers/stories/diamond-bg.png);
+  background-image: image-url('customers/stories/diamond-bg.png');
   background-repeat: repeat;
   padding: 75px 0;
 }
@@ -173,7 +173,7 @@
   }
 }
 .researchkit {
-  background-image: url(/images/customers/stories/researchkit_2x.png);
+  background-image: image-url('customers/stories/researchkit_2x.png');
   background-size: contain;
   background-position: center center;
   background-repeat: no-repeat;
@@ -319,7 +319,7 @@
 .telepharm__header {
   padding: 25px;
   background-color: #3aa9e0;
-  background-image: url(/images/customers/stories/tp-hero-bg.png);
+  background-image: image-url('customers/stories/tp-hero-bg.png');
   background-position: 55% 10%;
   background-repeat: no-repeat;
   color: $white;

--- a/source/stylesheets/_home.scss
+++ b/source/stylesheets/_home.scss
@@ -263,7 +263,7 @@
 }
 
 .home__gridiron-graph {
-  background-image: url(/images/home/gridiron-graph-with-mask.png);
+  background-image: image-url('home/gridiron-graph-with-mask.png');
   background-position: top center;
   background-repeat: no-repeat;
   height: 760px;
@@ -405,7 +405,7 @@
 }
 
 .home-quote__logo {
-  background-image: url(/images/home/quote-bubble-point.svg);
+  background-image: image-url('home/quote-bubble-point.svg');
   background-position: center -23px;
   height: 100px;
   margin: 0px auto 0 auto;

--- a/source/stylesheets/bourbon/bourbon/library/_font-face.scss
+++ b/source/stylesheets/bourbon/bourbon/library/_font-face.scss
@@ -36,7 +36,7 @@
 ///   // CSS Output
 ///   @font-face {
 ///     font-family: "source-sans-pro";
-///     src: url("fonts/source-sans-pro-regular.woff2") format("woff2"),
+///     src: image-url("fonts/source-sans-pro-regular.woff2") format("woff2"),
 ///          url("fonts/source-sans-pro-regular.woff") format("woff");
 ///     font-style: normal;
 ///     font-weight: 400;

--- a/source/stylesheets/components/_angled-section-dividers.scss
+++ b/source/stylesheets/components/_angled-section-dividers.scss
@@ -1,5 +1,5 @@
 .angled-section-divider--left {
-  background-image: url('/images/section-dividers/angle-bg-left.svg');
+  background-image: image-url('section-dividers/angle-bg-left.svg');
   background-position: -5px bottom;
   background-repeat: no-repeat;
   background-size: contain;
@@ -7,7 +7,7 @@
 }
 
 .angled-section-divider--left--with-gradient {
-  background-image: url('/images/section-dividers/angle-bg-left.svg'),
+  background-image: image-url('section-dividers/angle-bg-left.svg'),
                     linear-gradient(0deg,
                                     #381c3b,
                                     #381c3b 300px,
@@ -20,8 +20,8 @@
 }
 
 .angled-section-divider--left-with-grid {
-  background-image: url('/images/section-dividers/angle-bg-left.svg'),
-                    url('/images/section-dividers/angle-bg-left.svg');
+  background-image: image-url('section-dividers/angle-bg-left.svg'),
+                    image-url('section-dividers/angle-bg-left.svg');
   background-position: bottom left, center bottom;
   background-repeat: no-repeat;
   background-size: contain;
@@ -29,8 +29,8 @@
 }
 
 .angled-section-dividers {
-  background-image: url('/images/section-dividers/angle-solid-bg.svg'),
-                    url('/images/section-dividers/angle-bg-left.svg');
+  background-image: image-url('section-dividers/angle-solid-bg.svg'),
+                    image-url('section-dividers/angle-bg-left.svg');
   background-position: bottom right, bottom left;
   background-repeat: no-repeat;
   background-size: contain;
@@ -48,7 +48,7 @@
 .angled-section-gradient,
 .angled-section-gradient--with-grid {
   background-color: transparent;
-  background-image: url(/images/section-dividers/angle-gradient-bg.svg),
+  background-image: image-url('section-dividers/angle-gradient-bg.svg'),
                     linear-gradient(0deg,
                                     #381c3b,
                                     #381c3b 300px,
@@ -68,8 +68,8 @@
 }
 
 .angled-section-gradient--with-grid {
-  background-image: url(/images/grid-bg-fade.png),
-                    url(/images/section-dividers/angle-gradient-bg.svg),
+  background-image: image-url('grid-bg-fade.png'),
+                    image-url('section-dividers/angle-gradient-bg.svg'),
                     linear-gradient(0deg,
                                     #381c3b,
                                     #381c3b 300px,

--- a/source/stylesheets/components/_comparison-table.scss
+++ b/source/stylesheets/components/_comparison-table.scss
@@ -1,6 +1,6 @@
 .comparison-table {
   background: #273143;
-  background-image: url('/images/dusk-pix.svg');
+  background-image: image-url('dusk-pix.svg');
   background-position: top center;
   background-repeat: repeat-y;
   border-radius: 5px;

--- a/source/stylesheets/components/_header.scss
+++ b/source/stylesheets/components/_header.scss
@@ -9,7 +9,7 @@
   position: relative;
   &::before {
     background-color: transparent;
-    background-image: url(/images/header-bottom-grid.svg);
+    background-image: image-url('header-bottom-grid.svg');
     background-position: bottom center;
     background-repeat: no-repeat;
     background-size: cover;
@@ -49,7 +49,7 @@
 }
 
 .heading--large-gradient {
-  background-image: url(/images/hero-gradient--angled.svg);
+  background-image: image-url('hero-gradient--angled.svg');
   background-repeat: no-repeat;
 }
 
@@ -243,9 +243,9 @@
 }
 
 .hero-gradient-with-dividers--dark {
-  background-image: url(/images/section-dividers/angle-bg-left.svg),
-                    url(/images/section-dividers/angle-bg-left.svg),
-                    url(/images/header-bottom-grid.svg),
+  background-image: image-url('section-dividers/angle-bg-left.svg'),
+                    url('section-dividers/angle-bg-left.svg'),
+                    url('header-bottom-grid.svg'),
                     linear-gradient(43deg, #172231 0%, #172231 20%, #421832 100%);
   background-repeat: no-repeat;
   background-position: 0px 130%, 0px 110%, bottom center, center center;

--- a/source/stylesheets/components/_resources.scss
+++ b/source/stylesheets/components/_resources.scss
@@ -192,7 +192,7 @@
 }
 .resource__header-wrap {
   background-color: black;
-  background-image: url(/images/resources/default.png);
+  background-image: image-url('resources/default.png');
   background-size: cover;
   padding: 65px 30px;
 }

--- a/source/stylesheets/enclave/_hids.scss
+++ b/source/stylesheets/enclave/_hids.scss
@@ -1,5 +1,5 @@
 .enclave-hids-hero {
-  background-image: url(/images/grid-bg-fade.png),
+  background-image: image-url('grid-bg-fade.png'),
                     linear-gradient(180deg, #172231 0%, #172231 20%, #421832 100%);
   background-position: 50% 80%, center center;
   background-repeat: no-repeat;

--- a/source/stylesheets/enclave/_index.scss
+++ b/source/stylesheets/enclave/_index.scss
@@ -3,8 +3,8 @@ body.enclave header {
 }
 
 .enclave-hero {
-  background-image: url(/images/section-dividers/angle-bg-left.svg),
-                    url(/images/grid-bg-fade.png),
+  background-image: image-url('section-dividers/angle-bg-left.svg'),
+                    url('grid-bg-fade.png'),
                     linear-gradient(180deg, #172231 0%, #172231 20%, #421832 100%);
   background-position: -5px bottom, 180% center, center center;
   background-repeat: no-repeat;
@@ -173,7 +173,7 @@ body.enclave header {
 }
 
 .enclave__demo-app {
-  background-image: url(/images/enclave-dashboard.png);
+  background-image: image-url('enclave-dashboard.png');
   background-repeat: no-repeat;
   background-position: 55vw center;
   background-size: contain;
@@ -296,7 +296,7 @@ body.enclave header {
 }
 
 .enclave-carousel-hero {
-  background-image: url(/images/grid-bg-fade.png),
+  background-image: image-url('grid-bg-fade.png'),
                     linear-gradient(180deg, #172231 0%, #172231 20%, #421832 100%);
   background-position: center center;
   background-repeat: no-repeat;


### PR DESCRIPTION
`image-url` is required to reference CSS bg images with git-ref file names. I had been referencing some without this helper.

Added a link for the Managed HIDS page.
<img width="1440" alt="screen shot 2017-11-24 at 10 18 18 am" src="https://user-images.githubusercontent.com/94830/33219891-1f8b5b60-d102-11e7-9952-16eb83f8457e.png">