### PR TITLE
Add redirect for reference architecture diagram

### DIFF
--- a/data/redirects.yml
+++ b/data/redirects.yml
@@ -601,3 +601,5 @@
   url: "/resources/enclave-reference-architecture/"
 - loc: "/resources/enclave-reference-architecture-division-of-responsibilities/"
   url: "/resources/enclave-reference-architecture/"
+- loc: "/assets/aptible-reference-architecture.pdf"
+  url: "/assets/aptible-enclave-reference-architecture.pdf"


### PR DESCRIPTION
/assets/aptible-reference-architecture.pdf => /assets/aptible-enclave-reference-architecture.pdf