### PR TITLE
Order resources by section

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,4 @@ request or open an issue. We send t-shirts and swag to contributors.
 
 ## Copyright
 
-Copyright (c) 2017 [Aptible](https://www.aptible.com). All rights reserved.
-
-[<img src="https://secure.gravatar.com/avatar/566f0093e212d9b808c0cece8a32480e?s=60" style="border-radius: 50%;" alt="@gib" />](https://github.com/gib)
+Copyright (c) 2018 [Aptible](https://www.aptible.com). All rights reserved.

--- a/helpers/resource_helpers.rb
+++ b/helpers/resource_helpers.rb
@@ -30,40 +30,24 @@ module ResourceHelpers
       .sort_by { |p| -p.data['created_at'].to_time.to_i }
   end
 
+  def resources_by_category(category)
+    resources_for_index.select { |p| p.data.category == category }
+  end
+
   def enclave_resources
-    section_pages('Resources')
-      .select { |p| 
-        p.data['included_on_index'] && 
-        p.data.category == 'Enclave'
-      }
-      .sort_by { |p| -p.data['created_at'].to_time.to_i }
+    resources_by_category 'Enclave'
   end
 
   def gridiron_resources
-    section_pages('Resources')
-      .select { |p| 
-        p.data['included_on_index'] && 
-        p.data.category == 'Gridiron'
-      }
-      .sort_by { |p| -p.data['created_at'].to_time.to_i }
+    resources_by_category 'Gridiron'
   end
 
   def hipaa_resources
-    section_pages('Resources')
-      .select { |p| 
-        p.data['included_on_index'] && 
-        p.data.category == 'HIPAA'
-      }
-      .sort_by { |p| -p.data['created_at'].to_time.to_i }
+    resources_by_category 'HIPAA'
   end
 
   def aptible_update_resources
-    section_pages('Resources')
-      .select { |p| 
-        p.data['included_on_index'] && 
-        p.data.category == 'Aptible Updates'
-      }
-      .sort_by { |p| -p.data['created_at'].to_time.to_i }
+    resources_by_category 'Aptible Updates'
   end
 
   def resource_path(resource)

--- a/helpers/resource_helpers.rb
+++ b/helpers/resource_helpers.rb
@@ -30,6 +30,42 @@ module ResourceHelpers
       .sort_by { |p| -p.data['created_at'].to_time.to_i }
   end
 
+  def enclave_resources
+    section_pages('Resources')
+      .select { |p| 
+        p.data['included_on_index'] && 
+        p.data.category == 'Enclave'
+      }
+      .sort_by { |p| -p.data['created_at'].to_time.to_i }
+  end
+
+  def gridiron_resources
+    section_pages('Resources')
+      .select { |p| 
+        p.data['included_on_index'] && 
+        p.data.category == 'Gridiron'
+      }
+      .sort_by { |p| -p.data['created_at'].to_time.to_i }
+  end
+
+  def hipaa_resources
+    section_pages('Resources')
+      .select { |p| 
+        p.data['included_on_index'] && 
+        p.data.category == 'HIPAA'
+      }
+      .sort_by { |p| -p.data['created_at'].to_time.to_i }
+  end
+
+  def aptible_update_resources
+    section_pages('Resources')
+      .select { |p| 
+        p.data['included_on_index'] && 
+        p.data.category == 'Aptible Updates'
+      }
+      .sort_by { |p| -p.data['created_at'].to_time.to_i }
+  end
+
   def resource_path(resource)
     return if resource.nil?
     data = resource.data

--- a/source/resources/index.haml
+++ b/source/resources/index.haml
@@ -16,23 +16,59 @@ layout: 'layout'
         %a{ href: '/resources/' } Resources
       = partial 'follow-aptible-twitter-link'
     .grid-document
+      %h1 Enclave
       .resources-list
         .resources-list__column
-          - resources_for_index.each_with_index do |resource, index|
-            - if index.odd?
-              = partial 'resource-item',  locals: { resource: resource }
-
-          -# One-off for AWS vs Aptible
-          %a.resource-item{ href: '/aws-vs-aptible/' }
-            .resource-item__body
-              %h2.resource-item__title HIPAA Compliant Deployment: AWS vs Aptible
-              .resource-item__excerpt
-                Enjoy the scalability and security of the AWS cloud without needing
-                an entire DevOps team to manage it.
-        .resources-list__column
-          - resources_for_index.each_with_index do |resource, index|
+          - enclave_resources.each_with_index do |resource, index|
             - if index.even?
               = partial 'resource-item',  locals: { resource: resource }
+        .resources-list__column
+          - enclave_resources.each_with_index do |resource, index|
+            - if index.odd?
+              = partial 'resource-item',  locals: { resource: resource }        
+      
+      -# One-off for AWS vs Enclave
+      .resources-list
+        %a.resource-item{ href: '/aws-vs-aptible/' }
+          .resource-item__body
+            %h2.resource-item__title Enclave vs AWS
+            .resource-item__excerpt
+              Enjoy the isolation and scalability of AWS without needing
+              an entire DevOps team to secure and manage it.
+
+      %h1 Gridiron
+      .resources-list
+        .resources-list__column
+          - gridiron_resources.each_with_index do |resource, index|
+            - if index.even?
+              = partial 'resource-item',  locals: { resource: resource }
+        .resources-list__column
+          - gridiron_resources.each_with_index do |resource, index|
+            - if index.odd?
+              = partial 'resource-item',  locals: { resource: resource }        
+      
+      %h1 HIPAA
+      .resources-list
+        .resources-list__column
+          - hipaa_resources.each_with_index do |resource, index|
+            - if index.even?
+              = partial 'resource-item',  locals: { resource: resource }
+        .resources-list__column
+          - hipaa_resources.each_with_index do |resource, index|
+            - if index.odd?
+              = partial 'resource-item',  locals: { resource: resource }        
+
+
+      %h1 Aptible Updates
+      .resources-list
+        .resources-list__column
+          - aptible_update_resources.each_with_index do |resource, index|
+            - if index.even?
+              = partial 'resource-item',  locals: { resource: resource }
+        .resources-list__column
+          - aptible_update_resources.each_with_index do |resource, index|
+            - if index.odd?
+              = partial 'resource-item',  locals: { resource: resource }        
 
     .grid-aside
       = partial 'resources-aside'


### PR DESCRIPTION
cc @henryhund 

This PR updates the /resources index to have sections, making it easier to navigate. These sections correspond with the `category` attribute in the Contentful content model for "Resources."

Because `.each_with_index` gives a fresh index, I moved the even/odd checks to start with even (i.e. 0).

@sandersonet - Specs aren't passing for me locally, something to do with the resource date specified in Contentful being in UTC-4 and my local time being in UTC-8

<img width="1070" alt="screenshot 2018-02-25 11 36 02" src="https://user-images.githubusercontent.com/3422584/36645594-13c96530-1a20-11e8-83ce-fb879a1f7e8c.png">


