### PR TITLE
Add Contentful folders to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,10 @@ source/bower_components
 .env
 .aptible-space-hash
 data/customers.yml
+
+# Ignore Contentful
+source/blog/*
+source/changelog/*
+source/compliance/*
+source/learn/*
+source/resources/*


### PR DESCRIPTION
@sandersonet Not sure if this is appropriate, but after running `bundle exec rake contentful:pull`, git started listing the new files as untracked.