### PR TITLE
Don't deploy staging on release

### DIFF
--- a/script/travis-deploy.sh
+++ b/script/travis-deploy.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
+set -o xtrace
+set -o errexit
+set -o nounset
 
-set -e
+if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
+  if [ "$TRAVIS_BRANCH" == "release" ]; then
+    bundle exec rake deploy:production
+  fi
 
-if [ "$TRAVIS_BRANCH" == "release" ] &&
-   [ "$TRAVIS_PULL_REQUEST" == "false" ] ; then
-  bundle exec rake deploy:staging
-  bundle exec rake deploy:production
-fi
-
-if [ "$TRAVIS_BRANCH" == "master" ] &&
-   [ "$TRAVIS_PULL_REQUEST" == "false" ] ; then
-  bundle exec rake deploy:staging
+  if [ "$TRAVIS_BRANCH" == "master" ]; then
+    bundle exec rake deploy:staging
+  fi
 fi


### PR DESCRIPTION
Deploying staging pulls drafts from Contentful, and then they never get
cleaned up, and they end up released to production. We don't want this:
instead, we should make sure the build environment is clean when running
a release build.

Note that since we always deploy to release by pushing the current
master branch, deploying to staging is redundant anyway.