### PR TITLE
Add marketing consent to all forms

### DIFF
--- a/source/contact/sales.haml
+++ b/source/contact/sales.haml
@@ -62,6 +62,9 @@ title: Contact Sales
             %textarea.input{ name: 'how-can-we-help' }
             .placeholder
               How can we help?
+      .grid-container.grid--1up
+        .grid-item.marketing-consent.contact-sales-page
+          = partial 'partials/ctas/marketing-consent'
       .grid-container.grid--2up
         .grid-item
           .form-action

--- a/source/enclave/hipaa-compliant-hosting.haml
+++ b/source/enclave/hipaa-compliant-hosting.haml
@@ -25,8 +25,6 @@ description: Aptible Enclave is a HIPAA compliant hosting platform, meeting secu
                 cta_placeholder: 'Enter your work email'  |
               }                                           |
 
-          = partial 'partials/signup-demo-request'
-
 .angled-section-dividers
 
 .content
@@ -113,8 +111,6 @@ description: Aptible Enclave is a HIPAA compliant hosting platform, meeting secu
             cta_label: 'Sign Up',                     |
             cta_placeholder: 'Enter your work email'  |
           }                                           |
-
-      = partial 'partials/signup-demo-request'
 
 .content.hipaa-hosting__tech-safeguards.angled-section-gradient--with-bottom-grid
   .grid-container

--- a/source/enclave/index.haml
+++ b/source/enclave/index.haml
@@ -24,7 +24,7 @@ description: Aptible Enclave is a container orchestration platform built for dev
               cta_placeholder: 'Enter your work email'  |
             }                                           |
 
-        .signup-cta__incentive
+        .signup-cta__incentive{ style: 'padding-top: 20px;' }
           %a{ href: '/documentation/' } Explore the Docs
           or
           %a{ href: '/contact/sales/' } Request a Demo
@@ -117,8 +117,6 @@ description: Aptible Enclave is a container orchestration platform built for dev
             cta_label: 'Sign Up',                     |
             cta_placeholder: 'Enter your work email'  |
           }                                           |
-
-      = partial 'partials/signup-demo-request'
 
       .deploy-now__terminal
         %pre.highlight.plaintext

--- a/source/enclave/managed-host-intrusion-detection-system.haml
+++ b/source/enclave/managed-host-intrusion-detection-system.haml
@@ -136,8 +136,6 @@ description: Aptible Enclave protects infrastructure with Managed Host-based Int
             cta_placeholder: 'Enter your work email'  |
           }                                           |
 
-      = partial 'partials/signup-demo-request'
-
 .angled-section-dividers
 
 .content.enclave-security-controls

--- a/source/gridiron.haml
+++ b/source/gridiron.haml
@@ -23,9 +23,6 @@ description: Aptible Gridiron helps developer teams set up and run robust
                 cta_label: 'Request A Demo',             |
                 cta_placeholder: 'Enter your work email' |
               }                                          |
-          %ul.signup-cta__incentives
-            %li.signup-cta__incentive Start your Risk Analysis
-            %li.signup-cta__incentive Prepare to pass audits and security reviews
 
         .home-hero__quotes
           .home__customer-quotes
@@ -144,6 +141,3 @@ description: Aptible Gridiron helps developer teams set up and run robust
             cta_label: 'Request A Demo',              |
             cta_placeholder: 'Enter your work email'  |
           }                                           |
-      %ul.signup-cta__incentives.signup-cta__incentives--center
-        %li.signup-cta__incentive Start your Risk Analysis
-        %li.signup-cta__incentive Prepare to pass audits and security reviews

--- a/source/index.haml
+++ b/source/index.haml
@@ -19,7 +19,6 @@ description: Deploy your app. Design your security management program. Meet the 
                 cta_label: 'Get Started',                 |
                 cta_placeholder: 'Enter your work email'  |
               }                                           |
-          = partial 'partials/signup-demo-request'
 
         .home-hero__quotes
           .home__customer-quotes
@@ -124,4 +123,3 @@ description: Deploy your app. Design your security management program. Meet the 
             cta_label: 'Get Started',                 |
             cta_placeholder: 'Enter your work email'  |
           }                                           |
-      = partial 'partials/signup-demo-request'

--- a/source/partials/_main-nav.haml
+++ b/source/partials/_main-nav.haml
@@ -9,11 +9,8 @@
     .nav--mobile
       %a.btn.btn--outline.btn--outline--white.nav-btn--login{ href: dashboard_href } Login
       %a.btn.nav-btn--signup{ href: open_account_href } Signup
-    #nav-item--signup.nav-item= partial 'partials/ctas/signup-cta', locals: { |
-                       cta_label: 'Get Started',                              |
-                       cta_placeholder: 'Enter your work email',              |
-                       class_name: 'signup-cta--small signup-cta--no-border'  |
-                     }                                                        |
+    #nav-item--signup.nav-item
+      %a.btn{ href: open_account_href } Get Started
 
   %a.nav-toggle
     .nav-toggle__expand

--- a/source/partials/_newsletter-signup--blog.haml
+++ b/source/partials/_newsletter-signup--blog.haml
@@ -10,3 +10,4 @@
     %input{ type: 'text', name: 'form-name', value: 'Newsletter Signup', style: 'display: none;' }
     %input.single-line__input{ required: true, name: 'newsletter-form__email', type: 'email', placeholder: 'Enter your email' }
     %button.single-line__submit{ type: 'submit'} Sign up
+    = partial 'partials/ctas/marketing-consent'

--- a/source/partials/_newsletter-signup.haml
+++ b/source/partials/_newsletter-signup.haml
@@ -5,3 +5,4 @@
   %input{ type: 'text', name: 'form-name', value: 'Newsletter Signup', style: 'display: none;' }
   %input#aptible-newsletter-subscription-email.newsletter-form__email{ required: true, name: 'newsletter-form__email', type: 'email', placeholder: 'Email Address' }
   %button.newsletter-form__submit{ type: 'submit', value: ' ' }
+  = partial 'partials/ctas/marketing-consent'

--- a/source/partials/ctas/_demo-cta.haml
+++ b/source/partials/ctas/_demo-cta.haml
@@ -8,3 +8,4 @@
   %input{ type: 'text', name: 'form-name', value: 'Request A Demo', style: 'display: none;' }
   %input.single-line__input{ type: 'email', name: 'gridiron-demo-request-form__email', placeholder: cta_placeholder, required: true }
   %button.single-line__submit{ type: 'submit' }= cta_label
+  = partial 'partials/ctas/marketing-consent'

--- a/source/partials/ctas/_easy-as-git-push.haml
+++ b/source/partials/ctas/_easy-as-git-push.haml
@@ -12,4 +12,3 @@
             cta_label: cta_label,                     |
             cta_placeholder: 'Enter your work email'  |
           }                                           |
-      = partial 'partials/signup-demo-request'

--- a/source/partials/ctas/_marketing-consent.haml
+++ b/source/partials/ctas/_marketing-consent.haml
@@ -1,10 +1,12 @@
+- form_id = rand(10000)
+
 .marketing-consent
   %ul.signup-cta__incentives
     %li.signup-cta__incentive
-      %input{ type: 'radio', name: 'marketing_consent', id: 'marketing_consent_yes', value: 'yes', checked: 'checked' }
-      %label{ for: 'marketing_consent_yes' }
+      %input{ type: 'radio', name: 'marketing_consent', id: "marketing_consent_yes_#{form_id}", value: 'yes', checked: 'checked' }
+      %label{ for: "marketing_consent_yes_#{form_id}" }
         Yes, I consent to receiving Aptible marketing emails. View the <a href="/legal/privacy/" target="_blank">Aptible Privacy Statement</a>
       %br
-      %input{ type: 'radio', name: 'marketing_consent', id: 'marketing_consent_no', value: 'no' }
-      %label{ for: 'marketing_consent_no' }
+      %input{ type: 'radio', name: 'marketing_consent', id: "marketing_consent_no_#{form_id}", value: 'no' }
+      %label{ for: "marketing_consent_no_#{form_id}" }
         No, I don't want to receive marketing emails.

--- a/source/partials/ctas/_marketing-consent.haml
+++ b/source/partials/ctas/_marketing-consent.haml
@@ -1,0 +1,10 @@
+.marketing-consent
+  %ul.signup-cta__incentives
+    %li.signup-cta__incentive
+      %input{ type: 'radio', name: 'marketing_consent', id: 'marketing_consent_yes', value: 'yes', checked: 'checked' }
+      %label{ for: 'marketing_consent_yes' }
+        Yes, I consent to receiving Aptible marketing emails. View the <a href="/legal/privacy/" target="_blank">Aptible Privacy Statement</a>
+      %br
+      %input{ type: 'radio', name: 'marketing_consent', id: 'marketing_consent_no', value: 'no' }
+      %label{ for: 'marketing_consent_no' }
+        No, I don't want to receive marketing emails.

--- a/source/partials/ctas/_signup-cta.haml
+++ b/source/partials/ctas/_signup-cta.haml
@@ -7,3 +7,4 @@
   %input{ type: 'text', name: 'form-name', value: 'Enclave Signup', style: 'display: none;' }
   %input.single-line__input{ type: 'email', name: 'email', placeholder: cta_placeholder, required: true }
   %button.single-line__submit{ type: 'submit' }= cta_label
+  = partial 'partials/ctas/marketing-consent'

--- a/source/partials/pricing/_need-more.haml
+++ b/source/partials/pricing/_need-more.haml
@@ -4,7 +4,6 @@
   .grid-container
     .pricing__need-more__title Need More?
     .pricing__need-more__subtitle
-      Deploy Enclave in your own AWS account, custom contracts,
-      audit assistance, and volume pricing available.
+      Custom contracts, audit assistance, and volume pricing available.
   .pricing__need-more__action
     %a.btn.signup-cta--small{ href: '/contact/sales/' } Contact Us

--- a/source/pricing/enclave.haml
+++ b/source/pricing/enclave.haml
@@ -32,11 +32,7 @@ tooltip_enterprise_support: 'Greater of $4,999 or 10% of monthly Aptible invoice
             Deploy to a free Development Stack now. Just pay for usage charged
             after your $500 credit.
         .price-credit-cta__credit $500 Free Credit
-        = partial 'partials/ctas/signup-cta', locals: {           |
-            cta_label: 'Sign Up',                                 |
-            cta_placeholder: 'Enter your work email',             |
-            class_name: 'signup-cta--small signup-cta--no-border' |
-          }                                                       |
+        %a.btn{ href: open_account_href, style: 'order: 3' } Get Started
 
 
 .content

--- a/source/stylesheets/components/_marketing-consent.scss
+++ b/source/stylesheets/components/_marketing-consent.scss
@@ -1,0 +1,34 @@
+.marketing-consent {
+  text-align: left;
+  padding-bottom: 10px;
+
+  .signup-cta__incentives {
+    margin: 0;
+  }
+
+  label {
+    display: inline;
+    cursor: pointer;
+  }
+
+  &.contact-sales-page {
+    padding: 10px 5px 20px;
+
+    label {
+      font-weight: 400;
+    }
+  }
+}
+
+
+.pricing-summary__body,
+.newsletter-form,
+.newsletter-signup--blog__form,
+.contact-sales-page {
+  .marketing-consent {
+    a {
+      color: $sky-blue;
+      border-bottom-color: $sky-blue;
+    }
+  }
+}


### PR DESCRIPTION
Adds a marketing consent toggle on every signup form on the site. Also removes the "enclave in your own AWS account" language.

This branch is up on staging: https://www.aptible-staging.com/
