### PR TITLE
Clarify stack language on pricing page

### DIFF
--- a/source/pricing/enclave.haml
+++ b/source/pricing/enclave.haml
@@ -197,7 +197,7 @@ tooltip_enterprise_support: 'Greater of $4,999 or 10% of monthly Aptible invoice
   .grid-container
     .pay-as-you-go
       .pay-as-you-go__title
-        Development and Staging Stacks are free and require no commitment
+        Development and staging environments require no commitment
       .pricing-summary__call-out Just Pay For Usage
       .pay-as-you-go__subtitle
         Easy to upgrade to Production stack when you're ready go live.


### PR DESCRIPTION
Shared stacks are free, but the containers are not. This was confusing at least one customer.

@fancyremarker 