### PR TITLE
Add "Aptible Resources" back into the main nav

### DIFF
--- a/source/partials/_nav-items.haml
+++ b/source/partials/_nav-items.haml
@@ -8,6 +8,9 @@
   %a.nav-item.nav-item--parent{ href: '#' } Resources
   %nav.nav-list__child-nav.nav-list__child-nav--developers
     .nav-item.nav-item--group.nav-item--with-arrow
+      %a{ href: "/resources/" }
+        .nav-item__title Aptible Resources
+    .nav-item.nav-item--group
       %a{ href: "#{base_doc_url}/documentation/" }
         .nav-item__title Documentation
       .nav-item__sub-nav--full


### PR DESCRIPTION
Adds "Aptible Resources" (`/resources/`) back into the main nav under the Resources tab.