### PR TITLE
Fix drift schedule a meeting links on paid landing pages

### DIFF
--- a/aptiblejs/src/analytics.js
+++ b/aptiblejs/src/analytics.js
@@ -63,12 +63,6 @@ export function identify(email) {
       url: currentURL()
     });
   }
-
-  if (window.drift) {
-    window.drift.identify(email, {
-      email: email
-    });
-  }
 }
 
 export function fireAllPixels() {

--- a/source/get/gridiron-demo.haml
+++ b/source/get/gridiron-demo.haml
@@ -149,21 +149,21 @@ description: Aptible Gridiron prepares your startup for information security aud
   - content_for :hide_footer
 
 
-%script{ async: true, src: "https://www.googletagmanager.com/gtag/js?id=AW-954754223" }
-:javascript
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'AW-954754223');
+- content_for :page_javascript do
+  %script{ async: true, src: "https://www.googletagmanager.com/gtag/js?id=AW-954754223" }
+  :javascript
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'AW-954754223');
 
-:javascript
-  $(function() {
-    animateHeadline();
+    $(function() {
+      animateHeadline();
 
-    $('.book-gridiron-demo').on('click', function(e) {
-      if (window.drift) {
-        e.preventDefault();
-        drift.api.startInteraction({ interactionId: 55785 });
-      }
+      $('.book-gridiron-demo').on('click', function(e) {
+        if (window.drift) {
+          e.preventDefault();
+          drift.api.startInteraction({ interactionId: 55785 });
+        }
+      });
     });
-  });


### PR DESCRIPTION
This PR:
- Moves page specific javascript on the "schedule a demo" landing page into `:page_javascript`
- Removes the `drift.identify` calls from `aptible.js`, which was causing drift meeting scheduling to fail for anonymous users (not sure why this caused drift to fail, but its an edge case not worth arguing about for now)
